### PR TITLE
make ccm to be installed on runtime

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -1,10 +1,21 @@
+import importlib
 import logging
 from pathlib import Path
+import subprocess
 
-from ccmlib import scylla_cluster as ccm
-from ccmlib.common import get_version_from_build
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+ccm_dir = Path(__file__).parent.parent / "scylla-ccm"
+if ccm_dir.exists():
+    logger.info("installing scylla-ccm from local directory %s", ccm_dir)
+    subprocess.check_call(['python', '-m', 'pip', 'install', str(ccm_dir.absolute())])
+else:
+    logger.info("scylla-ccm not found in local directory %s. Using preinstalled one.", ccm_dir)
+
+ccm = importlib.import_module('ccmlib.scylla_cluster')
+logger.info("scylla-ccm installed and imported successfully")
 
 
 class TestCluster:

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.10.12-bullseye AS python-build
 WORKDIR /app
 
 COPY requirements.txt .
-
+RUN pip install --no-cache-dir --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
 
 FROM golang:1.20.7 AS go-build

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,5 @@
 boto3==1.28.15
 botocore==1.31.15
-ccm @ git+https://github.com/scylladb/scylla-ccm@c5736fa3429d18b9521f712b619e0e202d17f096
 certifi==2023.7.22
 charset-normalizer==3.2.0
 exceptiongroup==1.1.2

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -e
+
+help_text="
+Script to run gocql driver matrix from within docker
+
+    Optional values can be set via environment variables
+    GOCQL_MATRIX_DIR, GOCQL_DRIVER_DIR, CCM_DIR
+
+    export GOCQL_DRIVER_DIR=`pwd`/../gocql-scylla
+    scripts/run_test.sh python3 main.py --tests integration --versions 1 --protocols 3 --scylla-version 5.2.4
+"
+
+here="$(realpath $(dirname "$0"))"
+DOCKER_IMAGE="$(<"$here/image")"
+
+export GOCQL_MATRIX_DIR=${GOCQL_MATRIX_DIR:-`pwd`}
+export GOCQL_DRIVER_DIR=${GOCQL_DRIVER_DIR:-`pwd`/../gocql-scylla}
+export CCM_DIR=${CCM_DIR:-`pwd`/../scylla-ccm}
+
+if [[ ! -d ${GOCQL_MATRIX_DIR} ]]; then
+    echo -e "\e[31m\$GOCQL_MATRIX_DIR = $GOCQL_MATRIX_DIR doesn't exist\e[0m"
+    echo "${help_text}"
+    exit 1
+fi
+if [[ ! -d ${CCM_DIR} ]]; then
+    echo -e "\e[31m\$CCM_DIR = $CCM_DIR doesn't exist\e[0m"
+    echo "${help_text}"
+    exit 1
+fi
+
+mkdir -p ${HOME}/.ccm
+mkdir -p ${HOME}/.local/lib
+mkdir -p ${HOME}/.docker
+
+# export all BUILD_* env vars into the docker run
+BUILD_OPTIONS=$(env | sed -n 's/^\(BUILD_[^=]\+\)=.*/--env \1/p')
+# export all JOB_* env vars into the docker run
+JOB_OPTIONS=$(env | sed -n 's/^\(JOB_[^=]\+\)=.*/--env \1/p')
+# export all AWS_* env vars into the docker run
+AWS_OPTIONS=$(env | sed -n 's/^\(AWS_[^=]\+\)=.*/--env \1/p')
+
+# if in jenkins also mount the workspace into docker
+if [[ -d ${WORKSPACE} ]]; then
+WORKSPACE_MNT="-v ${WORKSPACE}:${WORKSPACE}"
+else
+WORKSPACE_MNT=""
+fi
+
+DOCKER_CONFIG_MNT="-v $(eval echo ~${USER})/.docker:${HOME}/.docker"
+
+if [[ -z ${SCYLLA_VERSION} ]]; then
+      echo -e "\e[31m\$SCYLLA_VERSION is not set\e[0m"
+      echo "${help_text}"
+      exit 1
+fi
+
+# export all SCYLLA_* env vars into the docker run
+SCYLLA_OPTIONS=$(env | sed -n 's/^\(SCYLLA_[^=]\+\)=.*/--env \1/p')
+
+group_args=()
+for gid in $(id -G); do
+    group_args+=(--group-add "$gid")
+done
+
+docker_cmd="docker run --detach=true \
+    ${WORKSPACE_MNT} \
+    ${SCYLLA_OPTIONS} \
+    ${DOCKER_CONFIG_MNT} \
+    -v ${GOCQL_MATRIX_DIR}:/gocql-driver-matrix \
+    -v ${GOCQL_DRIVER_DIR}:/gocql \
+    -v ${CCM_DIR}:/scylla-ccm \
+    -e HOME \
+    -e SCYLLA_EXT_OPTS \
+    -e DEV_MODE \
+    -e WORKSPACE \
+    ${BUILD_OPTIONS} \
+    ${JOB_OPTIONS} \
+    ${AWS_OPTIONS} \
+    -w /gocql-driver-matrix \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+    -v /etc/passwd:/etc/passwd:ro \
+    -v /etc/group:/etc/group:ro \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    ${group_args[@]} \
+    --tmpfs ${HOME}/.cache \
+    --tmpfs ${HOME}/.config \
+    --tmpfs ${HOME}/.cassandra \
+    --tmpfs ${HOME}/go \
+    -v ${HOME}/.local:${HOME}/.local \
+    -v ${HOME}/.ccm:${HOME}/.ccm \
+    --network=host --privileged \
+    ${DOCKER_IMAGE} bash -c '$* /gocql'"
+
+echo "Running Docker: $docker_cmd"
+container=$(eval $docker_cmd)
+
+
+kill_it() {
+    if [[ -n "$container" ]]; then
+        docker rm -f "$container" > /dev/null
+        container=
+    fi
+}
+
+trap kill_it SIGTERM SIGINT SIGHUP EXIT
+
+docker logs "$container" -f
+
+if [[ -n "$container" ]]; then
+    exitcode="$(docker wait "$container")"
+else
+    exitcode=99
+fi
+
+echo "Docker exitcode: $exitcode"
+
+kill_it
+
+trap - SIGTERM SIGINT SIGHUP EXIT
+
+# after "docker kill", docker wait will not print anything
+[[ -z "$exitcode" ]] && exitcode=1
+
+exit "$exitcode"
+


### PR DESCRIPTION
Sometimes ccm requires updates to work with most recent packages and/or have some important bugfixes.

We want it to be updated automatically, without need to rebuild image. In order to do that, `ccm` is getting installed during runtime, when `cluster` module is imported.