### PR TITLE
remove python driver references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python Driver Matrix
+# Gocql Driver Matrix
 
 ## Prerequisites
 * Python3.10

--- a/email_sender.py
+++ b/email_sender.py
@@ -158,8 +158,8 @@ def get_ci_info():
     )
 
 
-def get_driver_origin_remote(python_driver_path):
-    return check_output(["bash", "-c", "git config --get remote.origin.url"], cwd=python_driver_path, text=True).strip()
+def get_driver_origin_remote(gocql_driver_path):
+    return check_output(["bash", "-c", "git config --get remote.origin.url"], cwd=gocql_driver_path, text=True).strip()
 
 
 def create_report(results, scylla_version, **kwargs):

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ def main(arguments: argparse.Namespace):
     driver_type = get_driver_type(arguments.gocql_driver_git)
     for driver_version in arguments.versions:
         for protocol in arguments.protocols:
-            logging.info('=== PYTHON DRIVER VERSION %s, PROTOCOL v%s ===', driver_version, protocol)
+            logging.info('=== GOCQL DRIVER VERSION %s, PROTOCOL v%s ===', driver_version, protocol)
             try:
                 result = Run(gocql_driver_git=arguments.gocql_driver_git,
                              driver_type=driver_type,
@@ -28,7 +28,7 @@ def main(arguments: argparse.Namespace):
                              scylla_version=arguments.scylla_version
                              ).run()
 
-                logging.info("=== (%s:%s) PYTHON DRIVER MATRIX RESULTS FOR PROTOCOL v%s ===",
+                logging.info("=== (%s:%s) GOCQL DRIVER MATRIX RESULTS FOR PROTOCOL v%s ===",
                              driver_type, driver_version, protocol)
                 logging.info(", ".join(f"{key}: {value}" for key, value in result.summary.items()))
                 if result.is_failed:
@@ -81,9 +81,9 @@ def get_driver_type(gocql_driver_git):
 def get_arguments() -> argparse.Namespace:
     default_protocols = ['3', '4']
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('gocql_driver_git', help='folder with git repository of python-driver', default="/gocql")
+    parser.add_argument('gocql_driver_git', help='folder with git repository of gocql-driver', default="/gocql")
     parser.add_argument('--versions', default="2", type=str,
-                        help="python-driver versions to test\n"
+                        help="gocql-driver versions to test\n"
                              "The value can be number or str with comma (example: 'v1.8.0,v1.7.3').\n"
                              "default=2 - take the two latest driver's tags.")
     parser.add_argument('--tests', default='integration',

--- a/processjunit.py
+++ b/processjunit.py
@@ -19,7 +19,7 @@ class ProcessJUnit:
         """
         Analyze report results and modify the result according to the "ignore" tests names in the YAML file.
         Also, create a new XML file with the correct run results after the analysis and change the "casetest" so that
-         the Jenkins can display all tests result (A job can run multiple python-driver runs).
+         the Jenkins can display all tests result (A job can run multiple gocql-driver runs).
         """
         tree = ElementTree.parse(self._xunit_file).find("testsuite[@name='github.com/gocql/gocql']")
         for element in tree.iter("testcase"):
@@ -78,21 +78,21 @@ class ProcessJUnit:
         return self._summary_full_details
 
     @lru_cache(maxsize=None)
-    def save_after_analysis(self, driver_version: str, protocol: int, python_driver_type: str) -> None:
+    def save_after_analysis(self, driver_version: str, protocol: int, gocql_driver_type: str) -> None:
         """
         Create a new XML file with the correct run results after filtering the names of the tests marked as "skip" in
         the YAML file.
-        Also, change "casetest" so that the Jenkins can display all tests result (A job can run multiple python-driver
+        Also, change "casetest" so that the Jenkins can display all tests result (A job can run multiple gocql-driver
         runs).
-        :param driver_version: The python-driver tag (Example: 3.25.0-scylla or 3.25.0)
+        :param driver_version: The gocql-driver tag (Example: 1.11.1 or 1.4.0)
         :param protocol: The cqlsh native protocol number
-        :param python_driver_type: The driver type - can be "scylla" or "datastax"
+        :param gocql_driver_type: The driver type - can be "scylla" or "upstream"
         """
         tree = ElementTree.parse(self._xunit_file).find("testsuite[@name='github.com/gocql/gocql']")
         new_tree = ElementTree.Element("testsuites")
         _ = [tree.attrib.__setitem__(key, str(value)) for key, value in self.summary.items()]
         pytest_child = ElementTree.SubElement(new_tree, "testsuite", attrib=tree.attrib)
-        new_test_prefix = f"{python_driver_type}_version_{driver_version}_v{protocol}_"
+        new_test_prefix = f"{gocql_driver_type}_version_{driver_version}_v{protocol}_"
 
         for element in tree.iter("testcase"):
             test_full_name = f"{element.attrib['classname']}.{element.attrib['name']}"

--- a/run.py
+++ b/run.py
@@ -47,7 +47,7 @@ class Run:
             if tag <= target_version:
                 return target_version_folder / str(tag)
         else:
-            raise ValueError("Not found directory for python-driver version '%s'", self.driver_version)
+            raise ValueError("Not found directory for gocql-driver version '%s'", self.driver_version)
 
     @cached_property
     def ignore_tests(self) -> Dict[str, List[str]]:
@@ -138,5 +138,5 @@ class Run:
                             env=self.environment, cwd=self._gocql_driver_git)
             cluster.remove()
             junit.save_after_analysis(driver_version=self.driver_version, protocol=self._protocol,
-                                      python_driver_type=self._driver_type)
+                                      gocql_driver_type=self._driver_type)
         return junit


### PR DESCRIPTION
Because code was based on python driver there were many leftovers from it that was not switched to gocql.

This commit removes all python-driver references and replaces with gocql equivalents.

fixes: https://github.com/scylladb/gocql-driver-matrix/issues/5