### PR TITLE
enable multiple tests in one run

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ export GOCQL_DRIVER_DIR=`pwd`/../gocql-scylla
 scripts/run_test.sh --tests integration --versions 1 --protocols 3 --scylla-version release:5.2.4
 
 ```
+
+## Available tests:
+* integration
+* database
+* ccm

--- a/cluster.py
+++ b/cluster.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Dict
 
 from ccmlib import scylla_cluster as ccm
 
@@ -10,22 +11,31 @@ logger = logging.getLogger(__name__)
 class TestCluster:
     """Responsible for configuring, starting and stopping cluster for tests"""
 
-    def __init__(self, driver_directory: Path, version: str) -> None:
+    def __init__(self, driver_directory: Path, version: str, configuration: Dict[str, str]) -> None:
         self.cluster_directory = driver_directory / "ccm"
         self.cluster_directory.mkdir(parents=True, exist_ok=True)
+        logger.info("Preparing test cluster binaries and configuration...")
         self._cluster: ccm.ScyllaCluster = ccm.ScyllaCluster(self.cluster_directory, 'test', cassandra_version=version)
+        cluster_config = {
+                "experimental_features": ["udf"],
+                "enable_user_defined_functions": "true",
+            }
+        cluster_config.update(configuration)
+        self._cluster.set_configuration_options(cluster_config)
         self._cluster.populate(1)
-        logger.info(self._cluster.version())
+        logger.info("Cluster prepared")
 
     @property
     def ip_addresses(self):
         storage_interfaces = [node.network_interfaces['storage'][0] for node in list(self._cluster.nodes.values()) if node.is_live()]
         return ",".join(storage_interfaces)
 
-    def start(self):
+    def start(self) -> str:
         logger.info("Starting test cluster...")
         self._cluster.start(wait_for_binary_proto=True)
+        nodes_count = len(self._cluster.nodes)
         logger.info("test cluster started")
+        return f"-rf={nodes_count} -clusterSize={nodes_count} -cluster={self.ip_addresses}"
 
     def remove(self):
         logger.info("Removing test cluster...")

--- a/configurations.py
+++ b/configurations.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import Literal, List, Dict
+
+
+@dataclass
+class TestConfiguration:
+    tags: List[str]
+    test_command_args: str
+    cluster_configuration: Dict[str, str]
+
+
+integration_tests = TestConfiguration(tags=["integration"], test_command_args='-timeout=1m -race -tags="integration"', cluster_configuration={})
+scylla_tests = TestConfiguration(tags=["scylla", "cassandra"], test_command_args='-timeout=1m -race -tags="scylla cassandra"', cluster_configuration={})
+ccm_tests = TestConfiguration(tags=["ccm"], test_command_args='-timeout=1m -race -tags="ccm"', cluster_configuration={})
+
+test_config_map = {
+    "integration": integration_tests,
+    "scylla": scylla_tests,
+    "ccm": ccm_tests,
+}

--- a/configurations.py
+++ b/configurations.py
@@ -10,11 +10,11 @@ class TestConfiguration:
 
 
 integration_tests = TestConfiguration(tags=["integration"], test_command_args='-timeout=1m -race -tags="integration"', cluster_configuration={})
-scylla_tests = TestConfiguration(tags=["scylla", "cassandra"], test_command_args='-timeout=1m -race -tags="scylla cassandra"', cluster_configuration={})
+database_tests = TestConfiguration(tags=["scylla", "cassandra"], test_command_args='-timeout=1m -race -tags="scylla cassandra"', cluster_configuration={})
 ccm_tests = TestConfiguration(tags=["ccm"], test_command_args='-timeout=1m -race -tags="ccm"', cluster_configuration={})
 
 test_config_map = {
     "integration": integration_tests,
-    "scylla": scylla_tests,
+    "database": database_tests,
     "ccm": ccm_tests,
 }

--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ def get_arguments() -> argparse.Namespace:
                              "The value can be number or str with comma (example: 'v1.8.0,v1.7.3').\n"
                              "default=2 - take the two latest driver's tags.")
     parser.add_argument('--tests', default='integration',
-                        help='"tags" to pass to go test command, default=integration')
+                        help='"tags" to pass to go test command, default=integration', nargs='+', choices=['integration', 'database', 'ccm'])
     parser.add_argument('--protocols', default=default_protocols,
                         help='cqlsh native protocol, default={}'.format(','.join(default_protocols)))
     parser.add_argument('--scylla-version', help="relocatable scylla version to use",

--- a/processjunit.py
+++ b/processjunit.py
@@ -7,12 +7,13 @@ from xml.etree import ElementTree
 
 class ProcessJUnit:
 
-    def __init__(self, xunit_file: Union[Path, str], ignore_set: Dict[str, Iterable[str]]):
+    def __init__(self, xunit_file: Path, ignore_set: Dict[str, Iterable[str]]):
         self._xunit_file = xunit_file
         self._ignore_set = {key: set(value) if value else set() for key, value in ignore_set.items()}
         self._summary = {"tests": 0, "errors": 0, "failures": 0, "skipped": 0, "xpassed": 0, "xfailed": 0,
                          "passed": 0, "ignored_in_analysis": 0, "flaky": 0}
         self._summary_full_details = {}
+
 
     @lru_cache(maxsize=None)
     def _analysis(self) -> None:
@@ -21,7 +22,7 @@ class ProcessJUnit:
         Also, create a new XML file with the correct run results after the analysis and change the "casetest" so that
          the Jenkins can display all tests result (A job can run multiple gocql-driver runs).
         """
-        tree = ElementTree.parse(self._xunit_file).find("testsuite[@name='github.com/gocql/gocql']")
+        tree = ElementTree.parse(self._xunit_file).find("testsuite")
         for element in tree.iter("testcase"):
             test_full_name = element.attrib['name']
             is_ignore_test = test_full_name in self._ignore_set["ignore"]
@@ -37,17 +38,6 @@ class ProcessJUnit:
                     category_type = "xpassed"
                     if is_ignore_test:
                         # The test passed, and it appears in the YAML file as a test that needs to skip - so need to
-                        # remove it from the YAML file
-                        category_type = "ignored_in_analysis"
-                elif category_type == "skipped":
-                    # The test is failed, but it's marked as "xfailed" because the test contains the
-                    # "@unittest.expectedFailure" mark and needs to remove it and write the test name inside the YAML
-                    # file
-                    category_type = "xfailed"
-                    if is_flaky_test:
-                        category_type = "flaky"
-                    elif is_ignore_test:
-                        # The test is failed, and it appears in the YAML file as a test that needs to skip - so need to
                         # remove it from the YAML file
                         category_type = "ignored_in_analysis"
                 elif is_ignore_test:
@@ -77,6 +67,37 @@ class ProcessJUnit:
         self._analysis()
         return self._summary_full_details
 
+    def _merge_part_results(self):
+        """
+        Merge the part files into one XML file.
+        """
+        test_cases = {}
+        time_taken = 0
+        timestamp = ""
+        part_files = sorted(self._xunit_file.parent.glob(f"{self._xunit_file.name}_part_*"))
+        for part in part_files:
+            tree = ElementTree.parse(part)
+            part_testsuites = tree.find("testsuite[@name='github.com/gocql/gocql']")
+            timestamp = part_testsuites.attrib.get('timestamp')
+            time_taken += float(part_testsuites.attrib.get('time', 0))
+            for elem in part_testsuites:
+                name = elem.attrib.get('name')
+                if not name:
+                    continue
+                # skipping update of given test case if it already exists in the dict and contains error or failure
+                if test_cases.get(name) and [elem for elem in test_cases.get(name) if elem.tag in ('failure', 'error')]:
+                    continue
+                test_cases[name] = elem
+
+        root = ElementTree.Element('testsuites')
+
+        root.append(ElementTree.Element('testsuite', attrib={'name': 'github.com/gocql/gocql', 'time': str(time_taken), 'timestamp': timestamp}))
+        for testcase in test_cases.values():
+            root[0].append(testcase)
+
+        tree = ElementTree.ElementTree(root)
+        tree.write(self._xunit_file, encoding='utf-8', xml_declaration=True)
+
     @lru_cache(maxsize=None)
     def save_after_analysis(self, driver_version: str, protocol: int, gocql_driver_type: str) -> None:
         """
@@ -88,16 +109,17 @@ class ProcessJUnit:
         :param protocol: The cqlsh native protocol number
         :param gocql_driver_type: The driver type - can be "scylla" or "upstream"
         """
+        self._merge_part_results()
         tree = ElementTree.parse(self._xunit_file).find("testsuite[@name='github.com/gocql/gocql']")
         new_tree = ElementTree.Element("testsuites")
         _ = [tree.attrib.__setitem__(key, str(value)) for key, value in self.summary.items()]
-        pytest_child = ElementTree.SubElement(new_tree, "testsuite", attrib=tree.attrib)
+        xunit_child = ElementTree.SubElement(new_tree, "testsuite", attrib=tree.attrib)
         new_test_prefix = f"{gocql_driver_type}_version_{driver_version}_v{protocol}_"
 
         for element in tree.iter("testcase"):
             test_full_name = element.attrib['name']
             element.attrib["classname"] = f"{new_test_prefix}{element.attrib['classname']}"
-            testcase_element = ElementTree.SubElement(pytest_child, "testcase", attrib=element.attrib)
+            testcase_element = ElementTree.SubElement(xunit_child, "testcase", attrib=element.attrib)
             if test_full_name not in self.summary_full_details.get("passed", {}) and \
                     test_full_name not in self.summary_full_details.get("xpassed", {}):
                 element_test_details = list(element.iter())[1]
@@ -112,11 +134,11 @@ class ProcessJUnit:
                 elif test_full_name in self.summary_full_details.get("ignored_in_analysis", {}):
                     message = "This test marked as 'skipped' because it appears in the YAML file as 'ignore' test"
                     tag_name = "skipped"
-                    element_test_details.attrib["type"] = "pytest.fail"
+                    element_test_details.attrib["type"] = "xunit.fail"
                 elif test_full_name in self.summary_full_details.get("flaky", {}):
                     message = "This test marked as 'skipped' because it appears in the YAML file as 'flaky' test"
                     tag_name = "skipped"
-                    element_test_details.attrib["type"] = "pytest.fail"
+                    element_test_details.attrib["type"] = "xunit.fail"
                 else:
                     tag_name = element_test_details.tag
                     if tag_name == "system-out":

--- a/processjunit.py
+++ b/processjunit.py
@@ -23,7 +23,7 @@ class ProcessJUnit:
         """
         tree = ElementTree.parse(self._xunit_file).find("testsuite[@name='github.com/gocql/gocql']")
         for element in tree.iter("testcase"):
-            test_full_name = f"{element.attrib['classname']}.{element.attrib['name']}"
+            test_full_name = element.attrib['name']
             is_ignore_test = test_full_name in self._ignore_set["ignore"]
             is_flaky_test = test_full_name in self._ignore_set["flaky"]
             if len(element):
@@ -95,7 +95,7 @@ class ProcessJUnit:
         new_test_prefix = f"{gocql_driver_type}_version_{driver_version}_v{protocol}_"
 
         for element in tree.iter("testcase"):
-            test_full_name = f"{element.attrib['classname']}.{element.attrib['name']}"
+            test_full_name = element.attrib['name']
             element.attrib["classname"] = f"{new_test_prefix}{element.attrib['classname']}"
             testcase_element = ElementTree.SubElement(pytest_child, "testcase", attrib=element.attrib)
             if test_full_name not in self.summary_full_details.get("passed", {}) and \
@@ -110,7 +110,7 @@ class ProcessJUnit:
                               " Please remove this mark from the test"
                     tag_name = "failure"
                 elif test_full_name in self.summary_full_details.get("ignored_in_analysis", {}):
-                    message = "This test marked as 'skipped' because it appears in the YAML file"
+                    message = "This test marked as 'skipped' because it appears in the YAML file as 'ignore' test"
                     tag_name = "skipped"
                     element_test_details.attrib["type"] = "pytest.fail"
                 elif test_full_name in self.summary_full_details.get("flaky", {}):
@@ -137,4 +137,4 @@ class ProcessJUnit:
     def is_failed(self) -> bool:
         return not (self.summary["tests"] and self.summary["tests"] ==
                     self.summary["passed"] + self.summary["skipped"] + self.summary["ignored_in_analysis"] +
-                    self.summary["flaky"] + self.summary["xpassed"])
+                    self.summary["flaky"] + self.summary["xpassed"] + self.summary["xfailed"])

--- a/run.py
+++ b/run.py
@@ -10,6 +10,7 @@ import yaml
 from packaging.version import Version, InvalidVersion
 
 from cluster import TestCluster
+from configurations import test_config_map, TestConfiguration
 from processjunit import ProcessJUnit
 
 
@@ -70,9 +71,10 @@ class Run:
         if not xunit_dir.exists():
             xunit_dir.mkdir(parents=True)
 
-        file_path = xunit_dir / f'pytest.{self._driver_type}.v{self._protocol}.{self.driver_version}.xml'
-        if file_path.exists():
-            file_path.unlink()
+        xunit_file_name = f'xunit.{self._driver_type}.v{self._protocol}.{self.driver_version}.xml'
+        file_path = xunit_dir / xunit_file_name
+        for parts in xunit_dir.glob(f"{xunit_file_name}*"):
+            parts.unlink()
         return file_path
 
     @cached_property
@@ -125,18 +127,21 @@ class Run:
 
     def run(self) -> ProcessJUnit:
         junit = ProcessJUnit(self.xunit_file, self.ignore_tests)
-        cluster = TestCluster(self._gocql_driver_git, self._scylla_version)
-        cluster.start()
         logging.info("Changing the current working directory to the '%s' path", self._gocql_driver_git)
         os.chdir(self._gocql_driver_git)
         if self._checkout_branch() and self._apply_patch_files():
-            args = f"-gocql.timeout=60s -proto={self._protocol} -rf=1 -clusterSize=1 -autowait=2000ms -compressor=snappy -gocql.cversion={self._cversion} -cluster={cluster.ip_addresses}"
-            go_test_cmd = f'go test -v -timeout=1m -race -tags="{self._test_tags}" {args} ./...  2>&1 | go-junit-report -iocopy -out {self.xunit_file}'
+            for idx, test in enumerate(self._test_tags):
+                test_config: TestConfiguration = test_config_map[test]
+                cluster = TestCluster(self._gocql_driver_git, self._scylla_version, configuration=test_config.cluster_configuration)
+                cluster_params = cluster.start()
+                logging.info("Run tests for tag '%s'", test)
+                args = f"-gocql.timeout=60s -proto={self._protocol} -autowait=2000ms -compressor=snappy -gocql.cversion={self._cversion}"
+                go_test_cmd = f'go test -v {test_config.test_command_args} {cluster_params} {args} ./...  2>&1 | go-junit-report -iocopy -out {self.xunit_file}_part_{idx}'
 
-            logging.info("Running the command '%s'", go_test_cmd)
-            subprocess.call(f"{go_test_cmd}", shell=True, executable="/bin/bash",
-                            env=self.environment, cwd=self._gocql_driver_git)
-            cluster.remove()
+                logging.info("Running the command '%s'", go_test_cmd)
+                subprocess.call(f"{go_test_cmd}", shell=True, executable="/bin/bash",
+                                env=self.environment, cwd=self._gocql_driver_git)
+                cluster.remove()
             junit.save_after_analysis(driver_version=self.driver_version, protocol=self._protocol,
                                       gocql_driver_type=self._driver_type)
         return junit

--- a/versions/scylla/1.11.0/ignore.yaml
+++ b/versions/scylla/1.11.0/ignore.yaml
@@ -2,6 +2,9 @@
 tests:
   ignore:
   flaky:
+  - TestWriteFailure
 v4_tests:
   ignore:
+  - TestUDF
   flaky:
+  - TestWriteFailure

--- a/versions/scylla/1.11.1/ignore.yaml
+++ b/versions/scylla/1.11.1/ignore.yaml
@@ -2,6 +2,9 @@
 tests:
   ignore:
   flaky:
+  - TestWriteFailure
 v4_tests:
   ignore:
+  - TestUDF
   flaky:
+  - TestWriteFailure

--- a/versions/scylla/1.8.0/ignore.yaml
+++ b/versions/scylla/1.8.0/ignore.yaml
@@ -2,6 +2,9 @@
 tests:
   ignore:
   flaky:
+  - TestWriteFailure
 v4_tests:
   ignore:
+  - TestUDF
   flaky:
+  - TestWriteFailure

--- a/versions/upstream/1.4.0/ignore.yaml
+++ b/versions/upstream/1.4.0/ignore.yaml
@@ -1,7 +1,16 @@
 # Last verified state on Jul 31, 2023 by Łukasz Sójka
 tests:
   ignore:
+    - TestAggregateMetadata
+    - TestFunctionMetadata
+    - TestKeyspaceMetadata
   flaky:
+  - TestWriteFailure
 v4_tests:
   ignore:
+  - TestUDF
+  - TestAggregateMetadata
+  - TestFunctionMetadata
+  - TestKeyspaceMetadata
   flaky:
+  - TestWriteFailure

--- a/versions/upstream/1.5.1/ignore.yaml
+++ b/versions/upstream/1.5.1/ignore.yaml
@@ -1,7 +1,16 @@
 # Last verified state on Jul 31, 2023 by Łukasz Sójka
 tests:
   ignore:
+    - TestAggregateMetadata
+    - TestFunctionMetadata
+    - TestKeyspaceMetadata
   flaky:
+  - TestWriteFailure
 v4_tests:
   ignore:
+  - TestUDF
+  - TestAggregateMetadata
+  - TestFunctionMetadata
+  - TestKeyspaceMetadata
   flaky:
+  - TestWriteFailure

--- a/versions/upstream/1.5.2/ignore.yaml
+++ b/versions/upstream/1.5.2/ignore.yaml
@@ -1,7 +1,16 @@
 # Last verified state on Jul 31, 2023 by Łukasz Sójka
 tests:
   ignore:
+    - TestAggregateMetadata
+    - TestFunctionMetadata
+    - TestKeyspaceMetadata
   flaky:
+  - TestWriteFailure
 v4_tests:
   ignore:
+  - TestUDF
+  - TestAggregateMetadata
+  - TestFunctionMetadata
+  - TestKeyspaceMetadata
   flaky:
+  - TestWriteFailure


### PR DESCRIPTION
It was not possible to run multiple tags in one `go test` run because
they were failing (due some conflicts).

So, now it is possible to run `go test` multiple times against fresh
cluster (which may be configured differently for each `go test` run).
Later results from these runs are merged and analyzed.

also added some ignore/flaky tests to stabilize the result.