### PR TITLE
fix failing tests for upstream driver

### DIFF
--- a/versions/upstream/1.4.0/ignore.yaml
+++ b/versions/upstream/1.4.0/ignore.yaml
@@ -1,16 +1,23 @@
-# Last verified state on Jul 31, 2023 by Łukasz Sójka
+# Last verified state on Aug 29, 2023 by Łukasz Sójka
 tests:
   ignore:
-    - TestAggregateMetadata
-    - TestFunctionMetadata
-    - TestKeyspaceMetadata
+    - TestAggregateMetadata  # cassandra only
+    - TestFunctionMetadata  # cassandra only
+    - TestKeyspaceMetadata  # cassandra only
+    - TestGetTableMetadata  # cassandra only
+    - TestMaterializedViewMetadata  # cassandra only
+    - TestLexicalUUIDType  # cassandra only
+    - TestControlConn_ReconnectRefreshesRing  # skipped in scylladb/gocql
   flaky:
   - TestWriteFailure
 v4_tests:
   ignore:
-  - TestUDF
-  - TestAggregateMetadata
-  - TestFunctionMetadata
-  - TestKeyspaceMetadata
+  - TestUDF  # cassandra only
+  - TestAggregateMetadata  # cassandra only
+  - TestFunctionMetadata  # cassandra only
+  - TestKeyspaceMetadata  # cassandra only
+  - TestMaterializedViewMetadata  # cassandra only
+  - TestLexicalUUIDType  # cassandra only
+  - TestControlConn_ReconnectRefreshesRing  # skipped in scylladb/gocql
   flaky:
   - TestWriteFailure

--- a/versions/upstream/1.5.1/ignore.yaml
+++ b/versions/upstream/1.5.1/ignore.yaml
@@ -1,16 +1,23 @@
-# Last verified state on Jul 31, 2023 by Łukasz Sójka
+# Last verified state on Aug 29, 2023 by Łukasz Sójka
 tests:
   ignore:
-    - TestAggregateMetadata
-    - TestFunctionMetadata
-    - TestKeyspaceMetadata
+    - TestAggregateMetadata  # cassandra only
+    - TestFunctionMetadata  # cassandra only
+    - TestKeyspaceMetadata  # cassandra only
+    - TestGetTableMetadata  # cassandra only
+    - TestMaterializedViewMetadata  # cassandra only
+    - TestLexicalUUIDType  # cassandra only
+    - TestControlConn_ReconnectRefreshesRing  # skipped in scylladb/gocql
   flaky:
   - TestWriteFailure
 v4_tests:
   ignore:
-  - TestUDF
-  - TestAggregateMetadata
-  - TestFunctionMetadata
-  - TestKeyspaceMetadata
+  - TestUDF  # cassandra only
+  - TestAggregateMetadata  # cassandra only
+  - TestFunctionMetadata  # cassandra only
+  - TestKeyspaceMetadata  # cassandra only
+  - TestMaterializedViewMetadata  # cassandra only
+  - TestLexicalUUIDType  # cassandra only
+  - TestControlConn_ReconnectRefreshesRing  # skipped in scylladb/gocql
   flaky:
   - TestWriteFailure

--- a/versions/upstream/1.5.2/ignore.yaml
+++ b/versions/upstream/1.5.2/ignore.yaml
@@ -1,16 +1,23 @@
-# Last verified state on Jul 31, 2023 by Łukasz Sójka
+# Last verified state on Aug 29, 2023 by Łukasz Sójka
 tests:
   ignore:
-    - TestAggregateMetadata
-    - TestFunctionMetadata
-    - TestKeyspaceMetadata
+    - TestAggregateMetadata  # cassandra only
+    - TestFunctionMetadata  # cassandra only
+    - TestKeyspaceMetadata  # cassandra only
+    - TestGetTableMetadata  # cassandra only
+    - TestMaterializedViewMetadata  # cassandra only
+    - TestLexicalUUIDType  # cassandra only
+    - TestControlConn_ReconnectRefreshesRing  # skipped in scylladb/gocql
   flaky:
   - TestWriteFailure
 v4_tests:
   ignore:
-  - TestUDF
-  - TestAggregateMetadata
-  - TestFunctionMetadata
-  - TestKeyspaceMetadata
+  - TestUDF  # cassandra only
+  - TestAggregateMetadata  # cassandra only
+  - TestFunctionMetadata  # cassandra only
+  - TestKeyspaceMetadata  # cassandra only
+  - TestMaterializedViewMetadata  # cassandra only
+  - TestLexicalUUIDType  # cassandra only
+  - TestControlConn_ReconnectRefreshesRing  # skipped in scylladb/gocql
   flaky:
   - TestWriteFailure


### PR DESCRIPTION
Some tests are failing when running against Scylla - mostly because they're meant for cassandra. Scylla gocql tests filters them out.

Because most of them still are working, marking failing ones to be ignored in analysis so we have better coverage.

`TestControlConn_ReconnectRefreshesRing` is commented out in scylladb/gocql and waits for fixing - ignoring upstream test seems ok also.

fixes: #9