### PR TITLE
fix parallel test execution

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -1,11 +1,34 @@
 import logging
+import socket
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 from ccmlib import scylla_cluster as ccm
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def acquire_ip_prefix() -> Tuple[socket.socket, str]:
+    """gets unique ip prefix across whole machine,
+    so it's possible to run tests in parallel.
+
+    Returns tuple of lock (socket in that case) and ip prefix, where lock later needs to be released."""
+    logger.info("Getting machine-unique ip prefix to support parallel tests...")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    for index in range(1, 126):
+        try:
+            ip_prefix = f'127.0.{index}.'
+            sock.bind((f'{ip_prefix}1', 48783))  # random port
+            logger.info("Cluster ip prefix acquired: %s", ip_prefix)
+            return sock, ip_prefix
+        except OSError:
+            continue
+    raise ValueError(f"Couldn't acquire ip prefix - looks clusters are not cleared properly")
+
+
+def release_ip_prefix_lock(sock: socket.socket) -> None:
+    sock.close()
 
 
 class TestCluster:
@@ -15,7 +38,9 @@ class TestCluster:
         self.cluster_directory = driver_directory / "ccm"
         self.cluster_directory.mkdir(parents=True, exist_ok=True)
         logger.info("Preparing test cluster binaries and configuration...")
+        self._ip_prefix_lock, ip_prefix = acquire_ip_prefix()
         self._cluster: ccm.ScyllaCluster = ccm.ScyllaCluster(self.cluster_directory, 'test', cassandra_version=version)
+        self._cluster.set_ipprefix(ip_prefix)
         cluster_config = {
                 "experimental_features": ["udf"],
                 "enable_user_defined_functions": "true",
@@ -24,6 +49,13 @@ class TestCluster:
         self._cluster.set_configuration_options(cluster_config)
         self._cluster.populate(1)
         logger.info("Cluster prepared")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.remove()
+        release_ip_prefix_lock(self._ip_prefix_lock)
 
     @property
     def ip_addresses(self):


### PR DESCRIPTION
When tests are executed in parallel on the same machine (which happens
due scylla oss and enterprise pipelines may run simultaneously) one of
it fails with scylla port being busy error.

Added mechanism for setting unique cluster's ip prefix. Mechanism uses
network interface for creating lock for given ip prefix by binding to
some random port for cluster life duration.

refs: https://github.com/scylladb/qa-tasks/issues/1435