### PR TITLE
Remove database test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,4 @@ scripts/run_test.sh --tests integration --versions 1 --protocols 3 --scylla-vers
 
 ## Available tests:
 * integration
-* database
 * ccm

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ def get_arguments() -> argparse.Namespace:
                              "The value can be number or str with comma (example: 'v1.8.0,v1.7.3').\n"
                              "default=2 - take the two latest driver's tags.")
     parser.add_argument('--tests', default='integration',
-                        help='"tags" to pass to go test command, default=integration', nargs='+', choices=['integration', 'database', 'ccm'])
+                        help='"tags" to pass to go test command, default=integration', nargs='+', choices=['integration', 'ccm'])
     parser.add_argument('--protocols', default=default_protocols,
                         help='cqlsh native protocol, default={}'.format(','.join(default_protocols)))
     parser.add_argument('--scylla-version', help="relocatable scylla version to use",


### PR DESCRIPTION
It should be removed in #23 as `scylla` and `cassandra` tags are no longer used