### PR TITLE
Fix unit sockets tests

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -42,6 +42,7 @@ class TestCluster:
         self._cluster: ccm.ScyllaCluster = ccm.ScyllaCluster(self.cluster_directory, 'test', cassandra_version=version)
         self._cluster.set_ipprefix(ip_prefix)
         cluster_config = {
+                "maintenance_socket": "workdir",
                 "experimental_features": ["udf"],
                 "enable_user_defined_functions": "true",
             }

--- a/cluster.py
+++ b/cluster.py
@@ -68,7 +68,12 @@ class TestCluster:
         self._cluster.start(wait_for_binary_proto=True)
         nodes_count = len(self._cluster.nodes)
         logger.info("test cluster started")
-        return f"-rf={nodes_count} -clusterSize={nodes_count} -cluster={self.ip_addresses}"
+        path = "../gocql-scylla/ccm/test/node1/cql.m"
+        if not Path(path).exists():
+            logger.info("Cluster socket file %s is not found", path)
+            return f"-rf={nodes_count} -clusterSize={nodes_count} -cluster={self.ip_addresses}"
+        else:
+            return f"-rf={nodes_count} -clusterSize={nodes_count} -cluster={self.ip_addresses} -cluster-socket=../gocql-scylla/ccm/test/node1/cql.m"
 
     def remove(self):
         logger.info("Removing test cluster...")

--- a/versions/scylla/1.14.0/ignore.yaml
+++ b/versions/scylla/1.14.0/ignore.yaml
@@ -1,14 +1,12 @@
 # Last verified state on Jul 31, 2023 by Łukasz Sójka
 tests:
   ignore:
-  - TestUnixSockets
   skip:
   flaky:
   - TestWriteFailure
 v4_tests:
   ignore:
   - TestUDF
-  - TestUnixSockets
   skip:
   flaky:
   - TestWriteFailure

--- a/versions/scylla/1.15.1/ignore.yaml
+++ b/versions/scylla/1.15.1/ignore.yaml
@@ -1,9 +1,7 @@
 # Last verified state on Jul 31, 2023 by Łukasz Sójka
 tests:
   skip:
-  - TestUnixSockets
   - TestRecreateSchema
 v4_tests:
   skip:
-  - TestUnixSockets
   - TestRecreateSchema


### PR DESCRIPTION
This PR enables running unix sockets tests by:
* adding maintenance socket option to cluster configuration
* adding `-cluster-socket` option to `go test` command.

Fixes: https://github.com/scylladb/gocql/issues/578