### PR TITLE
Add warning for missing testsuite in part files during merge

### DIFF
--- a/processjunit.py
+++ b/processjunit.py
@@ -78,6 +78,9 @@ class ProcessJUnit:
         for part in part_files:
             tree = ElementTree.parse(part)
             part_testsuites = tree.find("testsuite[@name='github.com/gocql/gocql']")
+            if part_testsuites is None:
+                print(f"Warning: Could not find testsuite with name 'github.com/gocql/gocql' in {part}")
+                continue
             timestamp = part_testsuites.attrib.get('timestamp')
             time_taken += float(part_testsuites.attrib.get('time', 0))
             for elem in part_testsuites:


### PR DESCRIPTION
Adresses #41 

## Issue
The `processjunit.py` module crashes with `AttributeError: 'NoneType' object has no attribute 'attrib'` when Go tests fail to execute (e.g., due to permission errors like `go: exec go1.25.0: permission denied`). When tests fail before running, `go-junit-report` generates empty XML files (`<testsuites></testsuites>`) without any `testsuite` elements.

## Root Cause
The `_merge_part_results()` method assumes all part files contain a `testsuite` element with `name='github.com/gocql/gocql'`. When `tree.find()` returns `None` for empty part files, the code tries to access `attrib` on `None`, causing the crash.

## Fix
Added a null check in `_merge_part_results()]` to gracefully handle missing testsuite elements.