### PR TITLE
fix(v1.16.1): skip TestTablets tablet-hint check on Scylla 2025.x+

### DIFF
--- a/versions/scylla/1.16.1/patch
+++ b/versions/scylla/1.16.1/patch
@@ -16,7 +16,7 @@ diff --git a/tablet_integration_test.go b/tablet_integration_test.go
 index 946299d..db6bdea 100644
 --- a/tablet_integration_test.go
 +++ b/tablet_integration_test.go
-@@ -36,154 +36,30 @@ func TestTablets(t *testing.T) {
+@@ -36,154 +36,35 @@ func TestTablets(t *testing.T) {
 
  	ctx := context.Background()
 
@@ -119,6 +119,11 @@ index 946299d..db6bdea 100644
 -		// When it happens queries can hit wrong tablet despite tablet been just learned
 -		// Here we go for second attempt when it happens
 -		// Assumption is that having second tablet migration right away is impossible
++	// v1.16.1 does not implement tablet-learning that causes Scylla to stop sending hints,
++	// so on Scylla 2025.x+ (where tablets are enabled by default) hints never stop.
++	if flagCassVersion.Major >= 2025 {
++		t.Skip("Skipping tablet hint check on Scylla 2025.x+: v1.16.1 does not stop tablet hints on this server version")
++	}
 +	for i := 0; i < 5; i++ {
  		for attempt := 1; true; attempt++ {
 -			trace := NewTracer(session)


### PR DESCRIPTION
## Problem

`TestTablets` fails consistently when running driver v1.16.1 against Scylla 2025.4 (scylla-2025.4 pipeline, build #20).

The patched test logic in `versions/scylla/1.16.1/patch` checks that after the driver learns tablet routing, Scylla stops sending `tablets-routing-v1` custom payload hints. It retries up to 3 times and fails if hints never stop.

With Scylla 2025.4 + driver v1.16.1, tablets are enabled by default, and v1.16.1 does not implement the tablet-learning mechanism that would cause Scylla to stop sending hints. As a result, hints are **always** present and the test always fails after 3 attempts.

## Fix

Add a version guard in the patch so that when running on Scylla 2025.x+, the tablet-hint-stop check is skipped via `t.Skip(...)`.

The existing behavior on older Scylla versions (< 2025) is preserved: the test still verifies that hints eventually stop, which is the correct behavior for drivers that implement tablet learning.

## Testing

Verified the updated patch applies cleanly to v1.16.1:
```
$ patch --dry-run -p1 < versions/scylla/1.16.1/patch
checking file recreate_test.go
checking file tablet_integration_test.go
```

This fix targets the `scylla-2025.4` CI pipeline failure. The `scylla-master` and `scylla-2026.1` pipelines are unaffected (they don't use v1.16.1/proto v3 in a configuration that triggers this failure).