### PR TITLE
fix(v1.16.x, v1.17.x): mark TestRoutingKey as known-broken in proto v3

### DIFF
--- a/versions/scylla/1.16.1/ignore.yaml
+++ b/versions/scylla/1.16.1/ignore.yaml
@@ -1,4 +1,6 @@
 tests:
+  ignore:
+  - TestRoutingKey
   skip:
 v4_tests:
   skip:

--- a/versions/scylla/1.17.0/ignore.yaml
+++ b/versions/scylla/1.17.0/ignore.yaml
@@ -1,4 +1,6 @@
 tests:
+  ignore:
+  - TestRoutingKey
   skip:
 v4_tests:
   skip:


### PR DESCRIPTION
## Problem

`TestRoutingKey` fails consistently with proto v3 when testing `scylladb/gocql` v1.16.1 and v1.17.3 across affected CI pipelines:
- scylla-2025.4 (v1.16.1 and v1.17.3)
- scylla-2026.1 (v1.16.1 and v1.17.3)
- scylla-master (v1.17.3 only — v1.16.1 passes against 2026.2-dev since the fix is already in master)

## Root Cause

In `session.go`, `routingKeyInfo()` uses `s.KeyspaceMetadata()` to look up table metadata. When a `SCHEMA_CHANGE` event fires for a new table, `invalidateTableSchema()` removes the table from `Tables` and marks it in `tablesInvalidated` (a COW map in `metadata_scylla.go`). `GetKeyspace()` returns the cached keyspace **without** triggering a per-table refresh, so the routing key lookup fails with "no metadata available".

The fix is to use `s.TableMetadata(keyspace, table)` instead, which routes through `GetTable()` → `deduplicatedRefreshTable()` and properly handles the invalidation.

## Fix Already on Master

The fix is **already present** on `scylladb/gocql` master (at `session.go:858`, with the comment `// get the table metadata (uses TableMetadata to handle cache invalidation)`). It was merged after both v1.16.1 and v1.17.3 were tagged.

This PR marks `TestRoutingKey` as `ignore` (known-broken) for the v1.16.x and v1.17.x configurations, which suppresses the CI noise until new releases of `scylladb/gocql` that include the fix are cut.

## Changes

- `versions/scylla/1.17.0/ignore.yaml`: add `TestRoutingKey` to proto3 ignore list (covers v1.17.x)
- `versions/scylla/1.16.1/ignore.yaml`: add `TestRoutingKey` to proto3 ignore list (covers v1.16.x)

## Related

- Fix in scylladb/gocql: https://github.com/scylladb/gocql/blob/master/session.go#L856-L863
- Once new gocql releases include the fix, these entries can be removed from `ignore.yaml`.