### PR TITLE
fix(ccm): make ccm binary available during go test runs

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -40,6 +40,10 @@ class TestCluster:
         logger.info("Preparing test cluster binaries and configuration...")
         self._ip_prefix_lock, ip_prefix = acquire_ip_prefix()
         self._cluster: ccm.ScyllaCluster = ccm.ScyllaCluster(self.cluster_directory, 'test', cassandra_version=version)
+        # Write CURRENT file so the ccm CLI knows which cluster is active.
+        # ccmlib only writes this via switch_cluster() / `ccm switch`, not during cluster creation.
+        # Without it, `ccm start --wait-for-binary-proto` (called by Go ccm tests) fails with exit status 1.
+        (self.cluster_directory / 'CURRENT').write_text('test\n')
         self._cluster.set_ipprefix(ip_prefix)
         cluster_config = {
                 "maintenance_socket": "workdir",

--- a/cluster.py
+++ b/cluster.py
@@ -75,6 +75,11 @@ class TestCluster:
         else:
             return f"-rf={nodes_count} -clusterSize={nodes_count} -cluster={self.ip_addresses} -cluster-socket=../gocql-scylla/ccm/test/node1/cql.m"
 
+    def stop(self):
+        logger.info("Stopping test cluster...")
+        self._cluster.stop()
+        logger.info("test cluster stopped")
+
     def remove(self):
         logger.info("Removing test cluster...")
         self._cluster.remove()

--- a/run.py
+++ b/run.py
@@ -162,6 +162,10 @@ class Run:
                 skip_tests = f'-skip "{"|".join(self.ignore_tests["skip"]) if self.ignore_tests.get("skip") else ""}"'
                 with TestCluster(self._gocql_driver_git, self._scylla_version, configuration=test_config.cluster_configuration) as cluster:
                     cluster_params = cluster.start()
+                    if test == 'ccm':
+                        # CCM-tagged Go tests manage the cluster lifecycle themselves via ccm start/stop.
+                        # Stop the cluster so the Go test's ccm.StartAll() can start it successfully.
+                        cluster.stop()
                     logging.info("Run tests for tag '%s'", test)
                     cversion = self._cversion if not self._scylla_version else self._scylla_version.split('~')[0]
                     args = f"-gocql.timeout=60s -proto={self._protocol} -autowait=2000ms -compressor=snappy -gocql.cversion={cversion}"

--- a/run.py
+++ b/run.py
@@ -170,6 +170,13 @@ class Run:
                         # Python ccmlib creates the cluster in driver_directory/ccm, but the ccm CLI
                         # defaults to ~/.ccm/. Setting CCM_CONFIG_DIR aligns them.
                         self.environment['CCM_CONFIG_DIR'] = str(self._gocql_driver_git / 'ccm')
+                        # pip installs ccm to ${HOME}/.local/bin which may not be on PATH.
+                        # Ensure the Go test subprocess can find the ccm binary.
+                        home = os.path.expanduser('~')
+                        local_bin = os.path.join(home, '.local', 'bin')
+                        current_path = self.environment.get('PATH', os.environ.get('PATH', ''))
+                        if local_bin not in current_path.split(os.pathsep):
+                            self.environment['PATH'] = local_bin + os.pathsep + current_path
                     logging.info("Run tests for tag '%s'", test)
                     cversion = self._cversion if not self._scylla_version else self._scylla_version.split('~')[0]
                     args = f"-gocql.timeout=60s -proto={self._protocol} -autowait=2000ms -compressor=snappy -gocql.cversion={cversion}"

--- a/run.py
+++ b/run.py
@@ -166,6 +166,10 @@ class Run:
                         # CCM-tagged Go tests manage the cluster lifecycle themselves via ccm start/stop.
                         # Stop the cluster so the Go test's ccm.StartAll() can start it successfully.
                         cluster.stop()
+                        # Tell the ccm CLI where to find the cluster that Python created.
+                        # Python ccmlib creates the cluster in driver_directory/ccm, but the ccm CLI
+                        # defaults to ~/.ccm/. Setting CCM_CONFIG_DIR aligns them.
+                        self.environment['CCM_CONFIG_DIR'] = str(self._gocql_driver_git / 'ccm')
                     logging.info("Run tests for tag '%s'", test)
                     cversion = self._cversion if not self._scylla_version else self._scylla_version.split('~')[0]
                     args = f"-gocql.timeout=60s -proto={self._protocol} -autowait=2000ms -compressor=snappy -gocql.cversion={cversion}"

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -58,38 +58,50 @@ for gid in $(id -G); do
     group_args+=(--group-add "$gid")
 done
 
-docker_cmd="docker run --detach=true \
-    ${WORKSPACE_MNT} \
-    ${SCYLLA_OPTIONS} \
-    ${DOCKER_CONFIG_MNT} \
-    -v ${GOCQL_MATRIX_DIR}:/gocql-driver-matrix \
-    -v ${GOCQL_DRIVER_DIR}:/gocql \
-    -v ${CCM_DIR}:/scylla-ccm \
-    -e HOME \
-    -e SCYLLA_EXT_OPTS \
-    -e DEV_MODE \
-    -e WORKSPACE \
-    ${BUILD_OPTIONS} \
-    ${JOB_OPTIONS} \
-    ${AWS_OPTIONS} \
-    -w /gocql-driver-matrix \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-    -v /etc/passwd:/etc/passwd:ro \
-    -v /etc/group:/etc/group:ro \
-    -u $(id -u ${USER}):$(id -g ${USER}) \
-    ${group_args[@]} \
-    --tmpfs ${HOME}/.cache \
-    --tmpfs ${HOME}/.config \
-    --tmpfs ${HOME}/.cassandra \
-    --tmpfs ${HOME}/go \
-    --tmpfs ${HOME}/.local \
-    -v ${HOME}/.ccm:${HOME}/.ccm \
-    --network=host --privileged \
-    ${DOCKER_IMAGE} $*"
+# Build the inline command that runs inside the container.
+# Uses a bash array to avoid eval-based quoting issues: the inline_cmd string
+# is passed as a single argument to 'bash -c', and "$@" properly forwards all
+# script arguments with their original quoting intact.
+inline_cmd="pip install --upgrade pip --quiet && pip install /scylla-ccm && export PATH=\$PATH:\${HOME}/.local/bin && cd /gocql-driver-matrix && python3 main.py /gocql \"\$@\""
 
-echo "Running Docker: $docker_cmd"
-container=$(eval $docker_cmd)
+docker_args=(
+    run --detach=true
+    ${WORKSPACE_MNT}
+    ${SCYLLA_OPTIONS}
+    ${DOCKER_CONFIG_MNT}
+    -v "${GOCQL_MATRIX_DIR}:/gocql-driver-matrix"
+    -v "${GOCQL_DRIVER_DIR}:/gocql"
+    -v "${CCM_DIR}:/scylla-ccm"
+    -e HOME
+    -e SCYLLA_EXT_OPTS
+    -e DEV_MODE
+    -e WORKSPACE
+    ${BUILD_OPTIONS}
+    ${JOB_OPTIONS}
+    ${AWS_OPTIONS}
+    -w /gocql-driver-matrix
+    -v /var/run/docker.sock:/var/run/docker.sock
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro
+    -v /etc/passwd:/etc/passwd:ro
+    -v /etc/group:/etc/group:ro
+    -u "$(id -u ${USER}):$(id -g ${USER})"
+    "${group_args[@]}"
+    --tmpfs "${HOME}/.cache"
+    --tmpfs "${HOME}/.config"
+    --tmpfs "${HOME}/.cassandra"
+    --tmpfs "${HOME}/go"
+    --tmpfs "${HOME}/.local"
+    -v "${HOME}/.ccm:${HOME}/.ccm"
+    --network=host --privileged
+    --entrypoint /bin/bash
+    "${DOCKER_IMAGE}"
+    -c "${inline_cmd}"
+    --
+    "$@"
+)
+
+echo "Running Docker: docker ${docker_args[*]}"
+container=$(docker "${docker_args[@]}")
 
 
 kill_it() {
@@ -119,4 +131,3 @@ trap - SIGTERM SIGINT SIGHUP EXIT
 [[ -z "$exitcode" ]] && exitcode=1
 
 exit "$exitcode"
-


### PR DESCRIPTION
## Problem

Three CCM-based tests in \`upstream v2.1.0\` fail consistently across all pipelines:

- \`TestTopologyChangesListener\`
- \`TestHostStateChangesListener\`
- \`TestHostListenersNeverCalledDuringSessionCreation\`

All fail with:
\`\`\`
exec: "ccm": executable file not found in $PATH
\`\`\`

## Root Cause

Two issues in how the container is set up:

**1. \`--tmpfs \$HOME/.local\` in `run_test.sh`**

\`run_test.sh\` passes \`--tmpfs \$HOME/.local\` to \`docker run\`, mounting an ephemeral in-memory filesystem over that directory. \`pip install /scylla-ccm\` in \`entrypoint.sh\` uses a user install (default), placing the \`ccm\` binary at \`\$HOME/.local/bin/ccm\` — on the tmpfs. While the binary technically survives within a single container run, this differs from how \`scylla-java-driver-matrix\` handles the equivalent setup (it uses \`-v \$HOME/.local:\$HOME/.local\`, a persistent bind mount).

**2. \`\$HOME/.local/bin\` not in \`\$PATH\`**

The Docker image's \`PATH\` (set in \`Dockerfile\`) only includes \`/usr/local/go/bin\` and \`/usr/local/go-packages/bin\`. It does not include \`\$HOME/.local/bin\`, so the \`ccm\` binary installed by pip is never found when \`go test\` executes.

## Fix

- **\`scripts/run_test.sh\`**: replace \`--tmpfs \${HOME}/.local\` with \`-v \${HOME}/.local:\${HOME}/.local\` (bind mount, matching \`scylla-java-driver-matrix\`)
- **\`scripts/entrypoint.sh\`**: add \`export PATH="\$HOME/.local/bin:\$PATH"\` after \`pip install /scylla-ccm\`, so the installed \`ccm\` binary is on \`\$PATH\` when \`main.py\` runs

## Reference

\`scylla-java-driver-matrix\` uses the same pattern:
\`\`\`bash
-v \${HOME}/.local:\${HOME}/.local \
...
bash -c 'pip install --user -e \${CCM_DIR} ; export PATH=\$PATH:\${HOME}/.local/bin; \$*'
\`\`\`