### PR TITLE
skip(v1.17.3): skip TestBatch_Errors on proto v3 — TOCTOU nil panic in getConn

### DIFF
--- a/versions/scylla/1.17.3/ignore.yaml
+++ b/versions/scylla/1.17.3/ignore.yaml
@@ -1,4 +1,11 @@
 tests:
   skip:
+    # Proto v3 only: TOCTOU double-call race in v1.17.3's getTableMetadata —
+    # `session.getConn() == nil || !session.getConn().isScyllaConn()` evaluates
+    # getConn() twice; if the pool changes between calls, the second call can
+    # return nil, causing a nil receiver panic in isScyllaConn(). The fix was
+    # merged to scylladb/gocql master (commit 0210272) after v1.17.3 was tagged.
+    # Only triggers on proto v3 due to schema event timing differences.
+    - TestBatch_Errors
 v4_tests:
   skip:


### PR DESCRIPTION
## Problem

`scylla-2026.1` build #12 fails with a nil pointer panic in `scylladb/gocql v1.17.3` when running `TestBatch_Errors` under protocol v3:

```
panic: runtime error: invalid memory address or nil pointer dereference
    github.com/gocql/gocql.(*Conn).getScyllaSupported(...)  conn.go:250
    github.com/gocql/gocql.(*Conn).isScyllaConn(...)        scylla.go:364
    github.com/gocql/gocql.getTableMetadata(...)             metadata_scylla.go:1133
    github.com/gocql/gocql.(*metadataDescriber).refreshKeyspaceSchema(...)
    github.com/gocql/gocql.(*Session).handleSchemaEvent(...)
    created by github.com/gocql/gocql.(*eventDebouncer).flush
```

## Root cause

In v1.17.3, `getTableMetadata` evaluates `session.getConn()` twice on the same line:

```go
if session.getConn() == nil || !session.getConn().isScyllaConn() {
```

This is a TOCTOU race: between the two calls the connection pool can change state so the first call returns non-nil (passes the nil check) while the second call returns nil, causing `isScyllaConn()` to panic on a nil `*Conn` receiver.

The panic is triggered by a schema event (keyspace `gocql_test` CREATE) firing during test setup, which calls `refreshKeyspaceSchema` → `getTableMetadata` from a debounced goroutine.

It only manifests on proto v3 due to schema event timing differences vs. proto v4.

## Fix already upstream

The fix — storing `getConn()` in a local variable — was merged to `scylladb/gocql` master via commit `0210272` after v1.17.3 was tagged. It is not backported to v1.17.3.

## This PR

Skips `TestBatch_Errors` under `tests` (proto v3 only, per `run.py:73`) for v1.17.3 until the version is retired from the matrix.

## Validation

Staging build: https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/gocql-driver-matrix-2026.1/1/