### PR TITLE
fix: upstream SimpleStrategy→NTS patches + scylla v1.18.0 data race fix

### DIFF
--- a/versions/scylla/1.18.0/ignore.yaml
+++ b/versions/scylla/1.18.0/ignore.yaml
@@ -1,0 +1,4 @@
+tests:
+  skip:
+v4_tests:
+  skip:

--- a/versions/scylla/1.18.0/patch
+++ b/versions/scylla/1.18.0/patch
@@ -1,0 +1,170 @@
+diff --git a/scylla.go b/scylla.go
+index af15d50..cec703b 100644
+--- a/scylla.go
++++ b/scylla.go
+@@ -9,6 +9,7 @@ import (
+ 	"net"
+ 	"strconv"
+ 	"strings"
++	"sync"
+ 	"sync/atomic"
+ 	"syscall"
+ 	"time"
+@@ -383,6 +384,7 @@ type scyllaConnPicker struct {
+ 	address                    string
+ 	excessConns                []*Conn
+ 	conns                      []*Conn
++	mu                         sync.RWMutex
+ 	nrShards                   int
+ 	pos                        uint64
+ 	lastAttemptedShard         int
+@@ -419,6 +421,9 @@ func newScyllaConnPicker(conn *Conn, logger StdLogger) *scyllaConnPicker {
+ }
+ 
+ func (p *scyllaConnPicker) Pick(t Token, qry ExecutableQuery) *Conn {
++	p.mu.RLock()
++	defer p.mu.RUnlock()
++
+ 	if len(p.conns) == 0 {
+ 		return nil
+ 	}
+@@ -524,6 +529,9 @@ func (p *scyllaConnPicker) Put(conn *Conn) error {
+ 		return errors.New("server reported that it has no shards")
+ 	}
+ 
++	p.mu.Lock()
++	defer p.mu.Unlock()
++
+ 	if nrShards != p.nrShards {
+ 		if debug.Enabled {
+ 			p.logger.Printf("scylla: %s shard count changed from %d to %d, rebuilding connection pool",
+@@ -568,7 +576,7 @@ func (p *scyllaConnPicker) Put(conn *Conn) error {
+ 	}
+ 
+ 	if p.shouldCloseExcessConns() {
+-		p.closeExcessConns()
++		p.closeExcessConnsLocked()
+ 	}
+ 
+ 	return nil
+@@ -622,14 +630,20 @@ func (p *scyllaConnPicker) shouldCloseExcessConns() bool {
+ }
+ 
+ func (p *scyllaConnPicker) GetConnectionCount() int {
++	p.mu.RLock()
++	defer p.mu.RUnlock()
+ 	return p.nrConns
+ }
+ 
+ func (p *scyllaConnPicker) GetExcessConnectionCount() int {
++	p.mu.RLock()
++	defer p.mu.RUnlock()
+ 	return len(p.excessConns)
+ }
+ 
+ func (p *scyllaConnPicker) GetShardCount() int {
++	p.mu.RLock()
++	defer p.mu.RUnlock()
+ 	return p.nrShards
+ }
+ 
+@@ -648,6 +662,9 @@ func (p *scyllaConnPicker) Remove(conn *Conn) {
+ 		p.logger.Printf("scylla: %s remove shard %d connection", p.address, shard)
+ 	}
+ 
++	p.mu.Lock()
++	defer p.mu.Unlock()
++
+ 	if p.conns[shard] != nil {
+ 		p.conns[shard] = nil
+ 		p.nrConns--
+@@ -655,6 +672,8 @@ func (p *scyllaConnPicker) Remove(conn *Conn) {
+ }
+ 
+ func (p *scyllaConnPicker) InFlight() int {
++	p.mu.RLock()
++	defer p.mu.RUnlock()
+ 	result := 0
+ 	for _, conn := range p.conns {
+ 		if conn != nil {
+@@ -665,33 +684,44 @@ func (p *scyllaConnPicker) InFlight() int {
+ }
+ 
+ func (p *scyllaConnPicker) Size() (int, int) {
++	p.mu.RLock()
++	defer p.mu.RUnlock()
+ 	return p.nrConns, p.nrShards - p.nrConns
+ }
+ 
+ func (p *scyllaConnPicker) Close() {
+-	p.closeConns()
+-	p.closeExcessConns()
+-}
++	p.mu.Lock()
++	conns := p.conns
++	p.conns = nil
++	p.nrConns = 0
++	excessConns := p.excessConns
++	p.excessConns = nil
++	p.mu.Unlock()
+ 
+-func (p *scyllaConnPicker) closeConns() {
+-	if len(p.conns) == 0 {
++	// Close connections outside of the lock to avoid deadlocks when a
++	// connection close triggers HandleError. See scylladb/gocql#53.
++	if len(conns) > 0 {
+ 		if debug.Enabled {
+-			p.logger.Printf("scylla: %s no connections to close", p.address)
++			p.logger.Printf("scylla: %s closing %d connections", p.address, len(conns))
+ 		}
+-		return
++		go closeConns(conns...)
++	} else if debug.Enabled {
++		p.logger.Printf("scylla: %s no connections to close", p.address)
+ 	}
+ 
+-	conns := p.conns
+-	p.conns = nil
+-	p.nrConns = 0
+-
+-	if debug.Enabled {
+-		p.logger.Printf("scylla: %s closing %d connections", p.address, len(conns))
++	if len(excessConns) > 0 {
++		if debug.Enabled {
++			p.logger.Printf("scylla: %s closing %d excess connections", p.address, len(excessConns))
++		}
++		go closeConns(excessConns...)
++	} else if debug.Enabled {
++		p.logger.Printf("scylla: %s no excess connections to close", p.address)
+ 	}
+-	go closeConns(conns...)
+ }
+ 
+-func (p *scyllaConnPicker) closeExcessConns() {
++// closeExcessConnsLocked closes excess connections. Must be called with p.mu held.
++// The actual connection closing happens asynchronously outside the lock.
++func (p *scyllaConnPicker) closeExcessConnsLocked() {
+ 	if len(p.excessConns) == 0 {
+ 		if debug.Enabled {
+ 			p.logger.Printf("scylla: %s no excess connections to close", p.address)
+@@ -708,8 +738,8 @@ func (p *scyllaConnPicker) closeExcessConns() {
+ 	go closeConns(conns...)
+ }
+ 
+-// Closing must be done outside of hostConnPool lock. If holding a lock
+-// a deadlock can occur when closing one of the connections returns error on close.
++// closeConns closes a list of connections. Must be called outside of any lock
++// to avoid deadlocks when a connection close triggers HandleError.
+ // See scylladb/gocql#53.
+ func closeConns(conns ...*Conn) {
+ 	for _, conn := range conns {
+@@ -734,6 +764,9 @@ func (p *scyllaConnPicker) NextShard() (shardID, nrShards int) {
+ 		return 0, 0
+ 	}
+ 
++	p.mu.Lock()
++	defer p.mu.Unlock()
++
+ 	// Find the shard without a connection
+ 	// It's important to start counting from 1 here because we want
+ 	// to consider the next shard after the previously attempted one

--- a/versions/upstream/2.0.0/patch
+++ b/versions/upstream/2.0.0/patch
@@ -1,0 +1,339 @@
+diff --git a/batch_test.go b/batch_test.go
+index 57eafd6..a78ad42 100644
+--- a/batch_test.go
++++ b/batch_test.go
+@@ -122,9 +122,9 @@ func TestBatch_SetKeyspace(t *testing.T) {
+ 	const keyspaceStmt = `
+ 		CREATE KEYSPACE IF NOT EXISTS gocql_keyspace_override_test 
+ 		WITH replication = {
+-			'class': 'SimpleStrategy', 
+-			'replication_factor': '1'
+-		};
++			'class': 'NetworkTopologyStrategy', 
++			'datacenter1': '1'
++		} AND tablets = {'enabled': false};
+ `
+ 
+ 	err := session.Query(keyspaceStmt).Exec()
+diff --git a/cassandra_test.go b/cassandra_test.go
+index bc260e4..8e249ae 100644
+--- a/cassandra_test.go
++++ b/cassandra_test.go
+@@ -2245,15 +2245,15 @@ func TestGetKeyspaceMetadata(t *testing.T) {
+ 	if keyspaceMetadata.Name != "gocql_test" {
+ 		t.Errorf("Expected keyspace name to be 'gocql' but was '%s'", keyspaceMetadata.Name)
+ 	}
+-	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.SimpleStrategy" {
+-		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.SimpleStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
++	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.NetworkTopologyStrategy" {
++		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.NetworkTopologyStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
+ 	}
+ 	if keyspaceMetadata.StrategyOptions == nil {
+ 		t.Error("Expected replication strategy options map but was nil")
+ 	}
+-	rfStr, ok := keyspaceMetadata.StrategyOptions["replication_factor"]
++	rfStr, ok := keyspaceMetadata.StrategyOptions["datacenter1"]
+ 	if !ok {
+-		t.Fatalf("Expected strategy option 'replication_factor' but was not found in %v", keyspaceMetadata.StrategyOptions)
++		t.Fatalf("Expected strategy option 'datacenter1' but was not found in %v", keyspaceMetadata.StrategyOptions)
+ 	}
+ 	rfInt, err := strconv.Atoi(rfStr.(string))
+ 	if err != nil {
+@@ -3583,9 +3583,9 @@ func TestQuery_SetKeyspace(t *testing.T) {
+ 	const keyspaceStmt = `
+ 		CREATE KEYSPACE IF NOT EXISTS gocql_query_keyspace_override_test
+ 		WITH replication = {
+-			'class': 'SimpleStrategy',
+-			'replication_factor': '1'
+-		};
++			'class': 'NetworkTopologyStrategy',
++			'datacenter1': '1'
++		} AND tablets = {'enabled': false};
+ `
+ 
+ 	err := session.Query(keyspaceStmt).Exec()
+@@ -3876,9 +3876,9 @@ func TestStmtCacheUsesOverriddenKeyspace(t *testing.T) {
+ 
+ 	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-			'replication_factor' : 1
+-	}`
++		'class' : 'NetworkTopologyStrategy',
++			'datacenter1' : 1
++	} AND tablets = {'enabled': false}`
+ 
+ 	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_stmt_cache"))
+ 	if err != nil {
+@@ -3937,9 +3937,9 @@ func TestRoutingKeyCacheUsesOverriddenKeyspace(t *testing.T) {
+ 
+ 	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-			'replication_factor' : 1
+-	}`
++		'class' : 'NetworkTopologyStrategy',
++			'datacenter1' : 1
++	} AND tablets = {'enabled': false}`
+ 
+ 	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_routing_key_cache"))
+ 	if err != nil {
+diff --git a/common_test.go b/common_test.go
+index 299af3b..3be52f9 100644
+--- a/common_test.go
++++ b/common_test.go
+@@ -156,9 +156,9 @@ func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : %d
+-	}`, keyspace, *flagRF))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : %d
++	} AND tablets = {'enabled': false}`, keyspace, *flagRF))
+ 
+ 	if err != nil {
+ 		panic(fmt.Sprintf("unable to create keyspace: %v", err))
+diff --git a/example_batch_test.go b/example_batch_test.go
+index 2322a3b..36c80b5 100644
+--- a/example_batch_test.go
++++ b/example_batch_test.go
+@@ -35,7 +35,7 @@ import (
+ // Example_batch demonstrates how to execute a batch of statements.
+ func Example_batch() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.batches(pk int, ck int, description text, PRIMARY KEY(pk, ck));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_dynamic_columns_test.go b/example_dynamic_columns_test.go
+index 38f4c66..f4816aa 100644
+--- a/example_dynamic_columns_test.go
++++ b/example_dynamic_columns_test.go
+@@ -38,7 +38,7 @@ import (
+ // Example_dynamicColumns demonstrates how to handle dynamic column list.
+ func Example_dynamicColumns() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.table1(pk text, ck int, value1 text, value2 int, PRIMARY KEY(pk, ck));
+ 	insert into example.table1 (pk, ck, value1, value2) values ('a', 1, 'b', 2);
+ 	insert into example.table1 (pk, ck, value1, value2) values ('c', 3, 'd', 4);
+diff --git a/example_lwt_batch_test.go b/example_lwt_batch_test.go
+index 1d0acad..ec5e09f 100644
+--- a/example_lwt_batch_test.go
++++ b/example_lwt_batch_test.go
+@@ -35,7 +35,7 @@ import (
+ // ExampleBatch_MapExecCAS demonstrates how to execute a batch lightweight transaction.
+ func ExampleBatch_MapExecCAS() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.my_lwt_batch_table(pk text, ck text, version int, value text, PRIMARY KEY(pk, ck));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_lwt_test.go b/example_lwt_test.go
+index a7aa0a8..0ac1e9a 100644
+--- a/example_lwt_test.go
++++ b/example_lwt_test.go
+@@ -35,7 +35,7 @@ import (
+ // ExampleQuery_MapScanCAS demonstrates how to execute a single-statement lightweight transaction.
+ func ExampleQuery_MapScanCAS() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.my_lwt_table(pk int, version int, value text, PRIMARY KEY(pk));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_marshaler_test.go b/example_marshaler_test.go
+index 3b6c819..6a6021e 100644
+--- a/example_marshaler_test.go
++++ b/example_marshaler_test.go
+@@ -75,7 +75,7 @@ func (m *MyMarshaler) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
+ // Example_marshalerUnmarshaler demonstrates how to implement a Marshaler and Unmarshaler.
+ func Example_marshalerUnmarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.my_marshaler_table(pk int, value text, PRIMARY KEY(pk));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_nulls_test.go b/example_nulls_test.go
+index 4d0ab16..20b4cf2 100644
+--- a/example_nulls_test.go
++++ b/example_nulls_test.go
+@@ -37,7 +37,7 @@ import (
+ // column being null and empty string, you can unmarshal into *string field.
+ func Example_nulls() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.stringvals(id int, value text, PRIMARY KEY(id));
+ 	insert into example.stringvals (id, value) values (1, null);
+ 	insert into example.stringvals (id, value) values (2, '');
+diff --git a/example_paging_test.go b/example_paging_test.go
+index 8e2a123..76bb2a5 100644
+--- a/example_paging_test.go
++++ b/example_paging_test.go
+@@ -36,7 +36,7 @@ import (
+ // See also package documentation about paging.
+ func Example_paging() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.itoa(id int, description text, PRIMARY KEY(id));
+ 	insert into example.itoa (id, description) values (1, 'one');
+ 	insert into example.itoa (id, description) values (2, 'two');
+diff --git a/example_set_test.go b/example_set_test.go
+index faf73ea..aa6f4a8 100644
+--- a/example_set_test.go
++++ b/example_set_test.go
+@@ -35,7 +35,7 @@ import (
+ // Example_set demonstrates how to use sets.
+ func Example_set() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.sets(id int, value set<text>, PRIMARY KEY(id));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_setkeyspace_test.go b/example_setkeyspace_test.go
+index 93b9c1c..946d9e0 100644
+--- a/example_setkeyspace_test.go
++++ b/example_setkeyspace_test.go
+@@ -35,9 +35,9 @@ import (
+ // 3. Default session keyspace - LOWEST precedence
+ func Example_setKeyspace() {
+ 	/* The example assumes the following CQL was used to setup the keyspaces:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+-	create keyspace example2 with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+-	create keyspace example3 with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
++	create keyspace example2 with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
++	create keyspace example3 with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.users(id int, name text, PRIMARY KEY(id));
+ 	create table example2.users(id int, name text, PRIMARY KEY(id));
+ 	create table example3.users(id int, name text, PRIMARY KEY(id));
+diff --git a/example_structured_logging_test.go b/example_structured_logging_test.go
+index c5bd366..dcbb227 100644
+--- a/example_structured_logging_test.go
++++ b/example_structured_logging_test.go
+@@ -39,7 +39,7 @@ import (
+ // proper component separation to distinguish between application and driver logs.
+ func Example_structuredLogging() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.log_demo(id int, value text, PRIMARY KEY(id));
+ 	*/
+ 
+diff --git a/example_test.go b/example_test.go
+index 9172519..46215a4 100644
+--- a/example_test.go
++++ b/example_test.go
+@@ -34,7 +34,7 @@ import (
+ 
+ func Example() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.tweet(timeline text, id UUID, text text, PRIMARY KEY(id));
+ 	create index on example.tweet(timeline);
+ 	*/
+diff --git a/example_udt_map_test.go b/example_udt_map_test.go
+index 03018c3..52a99cf 100644
+--- a/example_udt_map_test.go
++++ b/example_udt_map_test.go
+@@ -36,7 +36,7 @@ import (
+ // See also Example_userDefinedTypesStruct and examples for UDTMarshaler and UDTUnmarshaler if you want to map to structs.
+ func Example_userDefinedTypesMap() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_marshaler_test.go b/example_udt_marshaler_test.go
+index b2dc6ac..b385d8e 100644
+--- a/example_udt_marshaler_test.go
++++ b/example_udt_marshaler_test.go
+@@ -55,7 +55,7 @@ func (m MyUDTMarshaler) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, er
+ // ExampleUDTMarshaler demonstrates how to implement a UDTMarshaler.
+ func ExampleUDTMarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_struct_test.go b/example_udt_struct_test.go
+index 1bfdc7b..fb23bb2 100644
+--- a/example_udt_struct_test.go
++++ b/example_udt_struct_test.go
+@@ -41,7 +41,7 @@ type MyUDT struct {
+ // See also examples for UDTMarshaler and UDTUnmarshaler if you need more control/better performance.
+ func Example_userDefinedTypesStruct() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_unmarshaler_test.go b/example_udt_unmarshaler_test.go
+index 2db6c61..d0c331f 100644
+--- a/example_udt_unmarshaler_test.go
++++ b/example_udt_unmarshaler_test.go
+@@ -56,7 +56,7 @@ func (m *MyUDTUnmarshaler) UnmarshalUDT(name string, info gocql.TypeInfo, data [
+ // ExampleUDTUnmarshaler demonstrates how to implement a UDTUnmarshaler.
+ func ExampleUDTUnmarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	insert into example.my_udt_table (pk, value) values (1, {field_a: 'a value', field_b: 42});
+diff --git a/example_vector_test.go b/example_vector_test.go
+index 8e88c32..b7bb6c1 100644
+--- a/example_vector_test.go
++++ b/example_vector_test.go
+@@ -32,7 +32,7 @@ import (
+ // Note: Requires Cassandra 5.0+ and a SAI index on the vector column for ANN search.
+ func Example_vector() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.vectors(
+ 		id int,
+ 		item_name text,
+diff --git a/keyspace_table_test.go b/keyspace_table_test.go
+index 7862b48..d3d7a88 100644
+--- a/keyspace_table_test.go
++++ b/keyspace_table_test.go
+@@ -61,9 +61,9 @@ func TestKeyspaceTable(t *testing.T) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : 1
+-	}`, keyspace))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : 1
++	} AND tablets = {'enabled': false}`, keyspace))
+ 
+ 	if err != nil {
+ 		t.Fatal("unable to create keyspace:", err)
+@@ -71,9 +71,9 @@ func TestKeyspaceTable(t *testing.T) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : 1
+-	}`, wrongKeyspace))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : 1
++	} AND tablets = {'enabled': false}`, wrongKeyspace))
+ 
+ 	if err != nil {
+ 		t.Fatal("unable to create keyspace:", err)

--- a/versions/upstream/2.0.0/patch
+++ b/versions/upstream/2.0.0/patch
@@ -1,0 +1,339 @@
+diff --git a/batch_test.go b/batch_test.go
+index 57eafd6..a78ad42 100644
+--- a/batch_test.go
++++ b/batch_test.go
+@@ -122,9 +122,9 @@ func TestBatch_SetKeyspace(t *testing.T) {
+ 	const keyspaceStmt = `
+ 		CREATE KEYSPACE IF NOT EXISTS gocql_keyspace_override_test 
+ 		WITH replication = {
+-			'class': 'SimpleStrategy', 
+-			'replication_factor': '1'
+-		};
++			'class': 'NetworkTopologyStrategy', 
++			'datacenter1': '1'
++		} AND tablets = {'enabled': false};
+ `
+ 
+ 	err := session.Query(keyspaceStmt).Exec()
+diff --git a/cassandra_test.go b/cassandra_test.go
+index bc260e4..8e249ae 100644
+--- a/cassandra_test.go
++++ b/cassandra_test.go
+@@ -2245,15 +2245,15 @@ func TestGetKeyspaceMetadata(t *testing.T) {
+ 	if keyspaceMetadata.Name != "gocql_test" {
+ 		t.Errorf("Expected keyspace name to be 'gocql' but was '%s'", keyspaceMetadata.Name)
+ 	}
+-	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.SimpleStrategy" {
+-		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.SimpleStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
++	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.NetworkTopologyStrategy" {
++		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.NetworkTopologyStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
+ 	}
+ 	if keyspaceMetadata.StrategyOptions == nil {
+ 		t.Error("Expected replication strategy options map but was nil")
+ 	}
+-	rfStr, ok := keyspaceMetadata.StrategyOptions["replication_factor"]
++	rfStr, ok := keyspaceMetadata.StrategyOptions["datacenter1"]
+ 	if !ok {
+-		t.Fatalf("Expected strategy option 'replication_factor' but was not found in %v", keyspaceMetadata.StrategyOptions)
++		t.Fatalf("Expected strategy option 'datacenter1' but was not found in %v", keyspaceMetadata.StrategyOptions)
+ 	}
+ 	rfInt, err := strconv.Atoi(rfStr.(string))
+ 	if err != nil {
+@@ -3583,9 +3583,9 @@ func TestQuery_SetKeyspace(t *testing.T) {
+ 	const keyspaceStmt = `
+ 		CREATE KEYSPACE IF NOT EXISTS gocql_query_keyspace_override_test
+ 		WITH replication = {
+-			'class': 'SimpleStrategy',
+-			'replication_factor': '1'
+-		};
++			'class': 'NetworkTopologyStrategy',
++			'datacenter1': '1'
++		} AND tablets = {'enabled': false};
+ `
+ 
+ 	err := session.Query(keyspaceStmt).Exec()
+@@ -3876,9 +3876,9 @@ func TestStmtCacheUsesOverriddenKeyspace(t *testing.T) {
+ 
+ 	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-			'replication_factor' : 1
+-	}`
++		'class' : 'NetworkTopologyStrategy',
++			'datacenter1' : 1
++	} AND tablets = {'enabled': false}`
+ 
+ 	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_stmt_cache"))
+ 	if err != nil {
+@@ -3937,9 +3937,9 @@ func TestRoutingKeyCacheUsesOverriddenKeyspace(t *testing.T) {
+ 
+ 	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-			'replication_factor' : 1
+-	}`
++		'class' : 'NetworkTopologyStrategy',
++			'datacenter1' : 1
++	} AND tablets = {'enabled': false}`
+ 
+ 	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_routing_key_cache"))
+ 	if err != nil {
+diff --git a/common_test.go b/common_test.go
+index 299af3b..3be52f9 100644
+--- a/common_test.go
++++ b/common_test.go
+@@ -156,9 +156,9 @@ func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : %d
+-	}`, keyspace, *flagRF))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : %d
++	} AND tablets = {'enabled': false}`, keyspace, *flagRF))
+ 
+ 	if err != nil {
+ 		panic(fmt.Sprintf("unable to create keyspace: %v", err))
+diff --git a/example_batch_test.go b/example_batch_test.go
+index 2322a3b..36c80b5 100644
+--- a/example_batch_test.go
++++ b/example_batch_test.go
+@@ -35,7 +35,7 @@ import (
+ // Example_batch demonstrates how to execute a batch of statements.
+ func Example_batch() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.batches(pk int, ck int, description text, PRIMARY KEY(pk, ck));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_dynamic_columns_test.go b/example_dynamic_columns_test.go
+index 38f4c66..f4816aa 100644
+--- a/example_dynamic_columns_test.go
++++ b/example_dynamic_columns_test.go
+@@ -38,7 +38,7 @@ import (
+ // Example_dynamicColumns demonstrates how to handle dynamic column list.
+ func Example_dynamicColumns() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.table1(pk text, ck int, value1 text, value2 int, PRIMARY KEY(pk, ck));
+ 	insert into example.table1 (pk, ck, value1, value2) values ('a', 1, 'b', 2);
+ 	insert into example.table1 (pk, ck, value1, value2) values ('c', 3, 'd', 4);
+diff --git a/example_lwt_batch_test.go b/example_lwt_batch_test.go
+index 1d0acad..ec5e09f 100644
+--- a/example_lwt_batch_test.go
++++ b/example_lwt_batch_test.go
+@@ -35,7 +35,7 @@ import (
+ // ExampleBatch_MapExecCAS demonstrates how to execute a batch lightweight transaction.
+ func ExampleBatch_MapExecCAS() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.my_lwt_batch_table(pk text, ck text, version int, value text, PRIMARY KEY(pk, ck));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_lwt_test.go b/example_lwt_test.go
+index a7aa0a8..0ac1e9a 100644
+--- a/example_lwt_test.go
++++ b/example_lwt_test.go
+@@ -35,7 +35,7 @@ import (
+ // ExampleQuery_MapScanCAS demonstrates how to execute a single-statement lightweight transaction.
+ func ExampleQuery_MapScanCAS() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.my_lwt_table(pk int, version int, value text, PRIMARY KEY(pk));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_marshaler_test.go b/example_marshaler_test.go
+index 3b6c819..6a6021e 100644
+--- a/example_marshaler_test.go
++++ b/example_marshaler_test.go
+@@ -75,7 +75,7 @@ func (m *MyMarshaler) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
+ // Example_marshalerUnmarshaler demonstrates how to implement a Marshaler and Unmarshaler.
+ func Example_marshalerUnmarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.my_marshaler_table(pk int, value text, PRIMARY KEY(pk));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_nulls_test.go b/example_nulls_test.go
+index 4d0ab16..20b4cf2 100644
+--- a/example_nulls_test.go
++++ b/example_nulls_test.go
+@@ -37,7 +37,7 @@ import (
+ // column being null and empty string, you can unmarshal into *string field.
+ func Example_nulls() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.stringvals(id int, value text, PRIMARY KEY(id));
+ 	insert into example.stringvals (id, value) values (1, null);
+ 	insert into example.stringvals (id, value) values (2, '');
+diff --git a/example_paging_test.go b/example_paging_test.go
+index 8e2a123..76bb2a5 100644
+--- a/example_paging_test.go
++++ b/example_paging_test.go
+@@ -36,7 +36,7 @@ import (
+ // See also package documentation about paging.
+ func Example_paging() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.itoa(id int, description text, PRIMARY KEY(id));
+ 	insert into example.itoa (id, description) values (1, 'one');
+ 	insert into example.itoa (id, description) values (2, 'two');
+diff --git a/example_set_test.go b/example_set_test.go
+index faf73ea..aa6f4a8 100644
+--- a/example_set_test.go
++++ b/example_set_test.go
+@@ -35,7 +35,7 @@ import (
+ // Example_set demonstrates how to use sets.
+ func Example_set() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.sets(id int, value set<text>, PRIMARY KEY(id));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_setkeyspace_test.go b/example_setkeyspace_test.go
+index 93b9c1c..946d9e0 100644
+--- a/example_setkeyspace_test.go
++++ b/example_setkeyspace_test.go
+@@ -35,9 +35,9 @@ import (
+ // 3. Default session keyspace - LOWEST precedence
+ func Example_setKeyspace() {
+ 	/* The example assumes the following CQL was used to setup the keyspaces:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+-	create keyspace example2 with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+-	create keyspace example3 with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
++	create keyspace example2 with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
++	create keyspace example3 with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.users(id int, name text, PRIMARY KEY(id));
+ 	create table example2.users(id int, name text, PRIMARY KEY(id));
+ 	create table example3.users(id int, name text, PRIMARY KEY(id));
+diff --git a/example_structured_logging_test.go b/example_structured_logging_test.go
+index c5bd366..dcbb227 100644
+--- a/example_structured_logging_test.go
++++ b/example_structured_logging_test.go
+@@ -39,7 +39,7 @@ import (
+ // proper component separation to distinguish between application and driver logs.
+ func Example_structuredLogging() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.log_demo(id int, value text, PRIMARY KEY(id));
+ 	*/
+ 
+diff --git a/example_test.go b/example_test.go
+index 9172519..46215a4 100644
+--- a/example_test.go
++++ b/example_test.go
+@@ -34,7 +34,7 @@ import (
+ 
+ func Example() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.tweet(timeline text, id UUID, text text, PRIMARY KEY(id));
+ 	create index on example.tweet(timeline);
+ 	*/
+diff --git a/example_udt_map_test.go b/example_udt_map_test.go
+index 03018c3..52a99cf 100644
+--- a/example_udt_map_test.go
++++ b/example_udt_map_test.go
+@@ -36,7 +36,7 @@ import (
+ // See also Example_userDefinedTypesStruct and examples for UDTMarshaler and UDTUnmarshaler if you want to map to structs.
+ func Example_userDefinedTypesMap() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_marshaler_test.go b/example_udt_marshaler_test.go
+index b2dc6ac..b385d8e 100644
+--- a/example_udt_marshaler_test.go
++++ b/example_udt_marshaler_test.go
+@@ -55,7 +55,7 @@ func (m MyUDTMarshaler) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, er
+ // ExampleUDTMarshaler demonstrates how to implement a UDTMarshaler.
+ func ExampleUDTMarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_struct_test.go b/example_udt_struct_test.go
+index 1bfdc7b..fb23bb2 100644
+--- a/example_udt_struct_test.go
++++ b/example_udt_struct_test.go
+@@ -41,7 +41,7 @@ type MyUDT struct {
+ // See also examples for UDTMarshaler and UDTUnmarshaler if you need more control/better performance.
+ func Example_userDefinedTypesStruct() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_unmarshaler_test.go b/example_udt_unmarshaler_test.go
+index 2db6c61..d0c331f 100644
+--- a/example_udt_unmarshaler_test.go
++++ b/example_udt_unmarshaler_test.go
+@@ -56,7 +56,7 @@ func (m *MyUDTUnmarshaler) UnmarshalUDT(name string, info gocql.TypeInfo, data [
+ // ExampleUDTUnmarshaler demonstrates how to implement a UDTUnmarshaler.
+ func ExampleUDTUnmarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	insert into example.my_udt_table (pk, value) values (1, {field_a: 'a value', field_b: 42});
+diff --git a/example_vector_test.go b/example_vector_test.go
+index 8e88c32..b7bb6c1 100644
+--- a/example_vector_test.go
++++ b/example_vector_test.go
+@@ -32,7 +32,7 @@ import (
+ // Note: Requires Cassandra 5.0+ and a SAI index on the vector column for ANN search.
+ func Example_vector() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.vectors(
+ 		id int,
+ 		item_name text,
+diff --git a/keyspace_table_test.go b/keyspace_table_test.go
+index 7862b48..d3d7a88 100644
+--- a/keyspace_table_test.go
++++ b/keyspace_table_test.go
+@@ -61,9 +61,9 @@ func TestKeyspaceTable(t *testing.T) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : 1
+-	}`, keyspace))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : 1
++	} AND tablets = {'enabled': false}`, keyspace))
+ 
+ 	if err != nil {
+ 		t.Fatal("unable to create keyspace:", err)
+@@ -71,9 +71,9 @@ func TestKeyspaceTable(t *testing.T) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : 1
+-	}`, wrongKeyspace))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : 1
++	} AND tablets = {'enabled': false}`, wrongKeyspace))
+ 
+ 	if err != nil {
+ 		t.Fatal("unable to create keyspace:", err)

--- a/versions/upstream/2.1.0/patch
+++ b/versions/upstream/2.1.0/patch
@@ -1,0 +1,397 @@
+diff --git a/batch_test.go b/batch_test.go
+index 57eafd6..a78ad42 100644
+--- a/batch_test.go
++++ b/batch_test.go
+@@ -122,9 +122,9 @@ func TestBatch_SetKeyspace(t *testing.T) {
+ 	const keyspaceStmt = `
+ 		CREATE KEYSPACE IF NOT EXISTS gocql_keyspace_override_test 
+ 		WITH replication = {
+-			'class': 'SimpleStrategy', 
+-			'replication_factor': '1'
+-		};
++			'class': 'NetworkTopologyStrategy', 
++			'datacenter1': '1'
++		} AND tablets = {'enabled': false};
+ `
+ 
+ 	err := session.Query(keyspaceStmt).Exec()
+diff --git a/cassandra_test.go b/cassandra_test.go
+index 2f386c8..060230a 100644
+--- a/cassandra_test.go
++++ b/cassandra_test.go
+@@ -2254,8 +2254,8 @@ func assertGetKeyspaceMetadata(t *testing.T, keyspaceMetadata *KeyspaceMetadata,
+ 	if keyspaceMetadata.Name != "gocql_test" {
+ 		t.Errorf("Expected keyspace name to be 'gocql' but was '%s'", keyspaceMetadata.Name)
+ 	}
+-	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.SimpleStrategy" {
+-		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.SimpleStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
++	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.NetworkTopologyStrategy" {
++		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.NetworkTopologyStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
+ 	}
+ 	if keyspaceMetadata.StrategyOptions == nil {
+ 		t.Error("Expected replication strategy options map but was nil")
+@@ -3912,8 +3912,8 @@ func TestQuery_SetKeyspace(t *testing.T) {
+ 	const keyspaceStmt = `
+ 		CREATE KEYSPACE IF NOT EXISTS gocql_query_keyspace_override_test
+ 		WITH replication = {
+-			'class': 'SimpleStrategy',
+-			'replication_factor': '1'
++			'class': 'NetworkTopologyStrategy',
++			'datacenter1': '1'
+ 		};
+ `
+ 
+@@ -4205,9 +4205,9 @@ func TestStmtCacheUsesOverriddenKeyspace(t *testing.T) {
+ 
+ 	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-			'replication_factor' : 1
+-	}`
++		'class' : 'NetworkTopologyStrategy',
++			'datacenter1' : 1
++	} AND tablets = {'enabled': false}`
+ 
+ 	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_stmt_cache"))
+ 	if err != nil {
+@@ -4266,9 +4266,9 @@ func TestRoutingKeyCacheUsesOverriddenKeyspace(t *testing.T) {
+ 
+ 	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-			'replication_factor' : 1
+-	}`
++		'class' : 'NetworkTopologyStrategy',
++			'datacenter1' : 1
++	} AND tablets = {'enabled': false}`
+ 
+ 	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_routing_key_cache"))
+ 	if err != nil {
+diff --git a/common_test.go b/common_test.go
+index 0ae7501..15beff3 100644
+--- a/common_test.go
++++ b/common_test.go
+@@ -161,9 +161,9 @@ func createKeyspaceWithRF(tb testing.TB, cluster *ClusterConfig, keyspace string
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : %d
+-	}`, keyspace, rf))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : %d
++	} AND tablets = {'enabled': false}`, keyspace, rf))
+ 
+ 	if err != nil {
+ 		panic(fmt.Sprintf("unable to create keyspace: %v", err))
+diff --git a/example_batch_test.go b/example_batch_test.go
+index 2322a3b..36c80b5 100644
+--- a/example_batch_test.go
++++ b/example_batch_test.go
+@@ -35,7 +35,7 @@ import (
+ // Example_batch demonstrates how to execute a batch of statements.
+ func Example_batch() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.batches(pk int, ck int, description text, PRIMARY KEY(pk, ck));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_dynamic_columns_test.go b/example_dynamic_columns_test.go
+index 38f4c66..f4816aa 100644
+--- a/example_dynamic_columns_test.go
++++ b/example_dynamic_columns_test.go
+@@ -38,7 +38,7 @@ import (
+ // Example_dynamicColumns demonstrates how to handle dynamic column list.
+ func Example_dynamicColumns() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.table1(pk text, ck int, value1 text, value2 int, PRIMARY KEY(pk, ck));
+ 	insert into example.table1 (pk, ck, value1, value2) values ('a', 1, 'b', 2);
+ 	insert into example.table1 (pk, ck, value1, value2) values ('c', 3, 'd', 4);
+diff --git a/example_event_listeners_test.go b/example_event_listeners_test.go
+index 942b2d5..f94b37f 100644
+--- a/example_event_listeners_test.go
++++ b/example_event_listeners_test.go
+@@ -201,7 +201,7 @@ func (l *HostStateListener) OnHostDown(event gocql.HostDownEvent) {
+ // (SchemaListenersMux, HostListenersMux, SessionReadyListenersMux).
+ func Example_eventListeners() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.events_demo(id int PRIMARY KEY, value text);
+ 	*/
+ 
+@@ -245,7 +245,7 @@ func Example_eventListeners() {
+ 	// Host Listener: Session ready, loading initial host state
+ 	//   Initial host: 127.0.0.1 (id: a1b2c3d4-e5f6-7890-abcd-ef1234567890, datacenter: datacenter1, rack: rack1, state: UP)
+ 	// Schema Listener: Session ready, loading initial schema state
+-	//   Initial keyspace: example (replication: org.apache.cassandra.locator.SimpleStrategy)
++	//   Initial keyspace: example (replication: org.apache.cassandra.locator.NetworkTopologyStrategy)
+ 	//     Initial table: example.events_demo
+ 	//   Initial keyspace: system (replication: org.apache.cassandra.locator.LocalStrategy)
+ 	//     Initial table: system.local
+diff --git a/example_lwt_batch_test.go b/example_lwt_batch_test.go
+index 1d0acad..ec5e09f 100644
+--- a/example_lwt_batch_test.go
++++ b/example_lwt_batch_test.go
+@@ -35,7 +35,7 @@ import (
+ // ExampleBatch_MapExecCAS demonstrates how to execute a batch lightweight transaction.
+ func ExampleBatch_MapExecCAS() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.my_lwt_batch_table(pk text, ck text, version int, value text, PRIMARY KEY(pk, ck));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_lwt_test.go b/example_lwt_test.go
+index a7aa0a8..0ac1e9a 100644
+--- a/example_lwt_test.go
++++ b/example_lwt_test.go
+@@ -35,7 +35,7 @@ import (
+ // ExampleQuery_MapScanCAS demonstrates how to execute a single-statement lightweight transaction.
+ func ExampleQuery_MapScanCAS() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.my_lwt_table(pk int, version int, value text, PRIMARY KEY(pk));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_marshaler_test.go b/example_marshaler_test.go
+index 3b6c819..6a6021e 100644
+--- a/example_marshaler_test.go
++++ b/example_marshaler_test.go
+@@ -75,7 +75,7 @@ func (m *MyMarshaler) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
+ // Example_marshalerUnmarshaler demonstrates how to implement a Marshaler and Unmarshaler.
+ func Example_marshalerUnmarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.my_marshaler_table(pk int, value text, PRIMARY KEY(pk));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_nulls_test.go b/example_nulls_test.go
+index 4d0ab16..20b4cf2 100644
+--- a/example_nulls_test.go
++++ b/example_nulls_test.go
+@@ -37,7 +37,7 @@ import (
+ // column being null and empty string, you can unmarshal into *string field.
+ func Example_nulls() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.stringvals(id int, value text, PRIMARY KEY(id));
+ 	insert into example.stringvals (id, value) values (1, null);
+ 	insert into example.stringvals (id, value) values (2, '');
+diff --git a/example_paging_test.go b/example_paging_test.go
+index 8e2a123..76bb2a5 100644
+--- a/example_paging_test.go
++++ b/example_paging_test.go
+@@ -36,7 +36,7 @@ import (
+ // See also package documentation about paging.
+ func Example_paging() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.itoa(id int, description text, PRIMARY KEY(id));
+ 	insert into example.itoa (id, description) values (1, 'one');
+ 	insert into example.itoa (id, description) values (2, 'two');
+diff --git a/example_set_test.go b/example_set_test.go
+index faf73ea..aa6f4a8 100644
+--- a/example_set_test.go
++++ b/example_set_test.go
+@@ -35,7 +35,7 @@ import (
+ // Example_set demonstrates how to use sets.
+ func Example_set() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.sets(id int, value set<text>, PRIMARY KEY(id));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_setkeyspace_test.go b/example_setkeyspace_test.go
+index 93b9c1c..946d9e0 100644
+--- a/example_setkeyspace_test.go
++++ b/example_setkeyspace_test.go
+@@ -35,9 +35,9 @@ import (
+ // 3. Default session keyspace - LOWEST precedence
+ func Example_setKeyspace() {
+ 	/* The example assumes the following CQL was used to setup the keyspaces:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+-	create keyspace example2 with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+-	create keyspace example3 with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
++	create keyspace example2 with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
++	create keyspace example3 with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.users(id int, name text, PRIMARY KEY(id));
+ 	create table example2.users(id int, name text, PRIMARY KEY(id));
+ 	create table example3.users(id int, name text, PRIMARY KEY(id));
+diff --git a/example_structured_logging_test.go b/example_structured_logging_test.go
+index c5bd366..dcbb227 100644
+--- a/example_structured_logging_test.go
++++ b/example_structured_logging_test.go
+@@ -39,7 +39,7 @@ import (
+ // proper component separation to distinguish between application and driver logs.
+ func Example_structuredLogging() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.log_demo(id int, value text, PRIMARY KEY(id));
+ 	*/
+ 
+diff --git a/example_test.go b/example_test.go
+index 9172519..46215a4 100644
+--- a/example_test.go
++++ b/example_test.go
+@@ -34,7 +34,7 @@ import (
+ 
+ func Example() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.tweet(timeline text, id UUID, text text, PRIMARY KEY(id));
+ 	create index on example.tweet(timeline);
+ 	*/
+diff --git a/example_udt_map_test.go b/example_udt_map_test.go
+index 03018c3..52a99cf 100644
+--- a/example_udt_map_test.go
++++ b/example_udt_map_test.go
+@@ -36,7 +36,7 @@ import (
+ // See also Example_userDefinedTypesStruct and examples for UDTMarshaler and UDTUnmarshaler if you want to map to structs.
+ func Example_userDefinedTypesMap() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_marshaler_test.go b/example_udt_marshaler_test.go
+index b2dc6ac..b385d8e 100644
+--- a/example_udt_marshaler_test.go
++++ b/example_udt_marshaler_test.go
+@@ -55,7 +55,7 @@ func (m MyUDTMarshaler) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, er
+ // ExampleUDTMarshaler demonstrates how to implement a UDTMarshaler.
+ func ExampleUDTMarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_struct_test.go b/example_udt_struct_test.go
+index 1bfdc7b..fb23bb2 100644
+--- a/example_udt_struct_test.go
++++ b/example_udt_struct_test.go
+@@ -41,7 +41,7 @@ type MyUDT struct {
+ // See also examples for UDTMarshaler and UDTUnmarshaler if you need more control/better performance.
+ func Example_userDefinedTypesStruct() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_unmarshaler_test.go b/example_udt_unmarshaler_test.go
+index 2db6c61..d0c331f 100644
+--- a/example_udt_unmarshaler_test.go
++++ b/example_udt_unmarshaler_test.go
+@@ -56,7 +56,7 @@ func (m *MyUDTUnmarshaler) UnmarshalUDT(name string, info gocql.TypeInfo, data [
+ // ExampleUDTUnmarshaler demonstrates how to implement a UDTUnmarshaler.
+ func ExampleUDTUnmarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	insert into example.my_udt_table (pk, value) values (1, {field_a: 'a value', field_b: 42});
+diff --git a/example_vector_test.go b/example_vector_test.go
+index 8e88c32..b7bb6c1 100644
+--- a/example_vector_test.go
++++ b/example_vector_test.go
+@@ -32,7 +32,7 @@ import (
+ // Note: Requires Cassandra 5.0+ and a SAI index on the vector column for ANN search.
+ func Example_vector() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false};
+ 	create table example.vectors(
+ 		id int,
+ 		item_name text,
+diff --git a/keyspace_table_test.go b/keyspace_table_test.go
+index 7862b48..d3d7a88 100644
+--- a/keyspace_table_test.go
++++ b/keyspace_table_test.go
+@@ -61,9 +61,9 @@ func TestKeyspaceTable(t *testing.T) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : 1
+-	}`, keyspace))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : 1
++	} AND tablets = {'enabled': false}`, keyspace))
+ 
+ 	if err != nil {
+ 		t.Fatal("unable to create keyspace:", err)
+@@ -71,9 +71,9 @@ func TestKeyspaceTable(t *testing.T) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : 1
+-	}`, wrongKeyspace))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : 1
++	} AND tablets = {'enabled': false}`, wrongKeyspace))
+ 
+ 	if err != nil {
+ 		t.Fatal("unable to create keyspace:", err)
+diff --git a/schema_events_test.go b/schema_events_test.go
+index ae9e245..3301f91 100644
+--- a/schema_events_test.go
++++ b/schema_events_test.go
+@@ -211,7 +211,7 @@ func testSchemaEventsKeyspace(t *testing.T, session *Session, listener *schemaCh
+ 
+ 	listener.clear()
+ 
+-	err := session.Query(fmt.Sprintf(`CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}`, ks)).Exec()
++	err := session.Query(fmt.Sprintf(`CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '1'} AND tablets = {'enabled': false}`, ks)).Exec()
+ 	require.NoError(t, err, "Expected no error creating keyspace")
+ 
+ 	require.Eventually(t, func() bool {
+@@ -220,12 +220,12 @@ func testSchemaEventsKeyspace(t *testing.T, session *Session, listener *schemaCh
+ 
+ 	// Verify that the listener received the keyspace created event
+ 	require.Equal(t, ks, listener.KeyspaceCreatedEvents[0].Keyspace.Name, "Expected keyspace created event to have correct keyspace name")
+-	require.Contains(t, listener.KeyspaceCreatedEvents[0].Keyspace.StrategyClass, "SimpleStrategy", "Expected keyspace created event to have correct replication class")
+-	require.Equal(t, "1", listener.KeyspaceCreatedEvents[0].Keyspace.StrategyOptions["replication_factor"], "Expected keyspace created event to have correct replication factor")
++	require.Contains(t, listener.KeyspaceCreatedEvents[0].Keyspace.StrategyClass, "NetworkTopologyStrategy", "Expected keyspace created event to have correct replication class")
++	require.Equal(t, "1", listener.KeyspaceCreatedEvents[0].Keyspace.StrategyOptions["datacenter1"], "Expected keyspace created event to have correct replication factor")
+ 
+ 	listener.clear()
+ 
+-	err = session.Query(fmt.Sprintf(`ALTER KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '2'}`, ks)).Exec()
++	err = session.Query(fmt.Sprintf(`ALTER KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '2'}`, ks)).Exec()
+ 	require.NoError(t, err, "Expected no error updating keyspace")
+ 
+ 	// Verify that the listener received the keyspace updated event
+@@ -237,13 +237,13 @@ func testSchemaEventsKeyspace(t *testing.T, session *Session, listener *schemaCh
+ 
+ 	// Old metadata
+ 	require.Equal(t, ks, listener.KeyspaceUpdatedEvents[0].Old.Name, "Expected keyspace updated event to have correct keyspace name")
+-	require.Contains(t, listener.KeyspaceUpdatedEvents[0].Old.StrategyClass, "SimpleStrategy", "Expected keyspace created event to have correct replication class")
+-	require.Equal(t, "1", listener.KeyspaceUpdatedEvents[0].Old.StrategyOptions["replication_factor"], "Expected keyspace updated event to have correct old replication factor")
++	require.Contains(t, listener.KeyspaceUpdatedEvents[0].Old.StrategyClass, "NetworkTopologyStrategy", "Expected keyspace created event to have correct replication class")
++	require.Equal(t, "1", listener.KeyspaceUpdatedEvents[0].Old.StrategyOptions["datacenter1"], "Expected keyspace updated event to have correct old replication factor")
+ 
+ 	// New metadata
+ 	require.Equal(t, ks, listener.KeyspaceUpdatedEvents[0].New.Name, "Expected keyspace updated event to have correct keyspace name")
+-	require.Contains(t, listener.KeyspaceUpdatedEvents[0].New.StrategyClass, "SimpleStrategy", "Expected keyspace updated event to have correct replication class")
+-	require.Equal(t, "2", listener.KeyspaceUpdatedEvents[0].New.StrategyOptions["replication_factor"], "Expected keyspace updated event to have correct new replication factor")
++	require.Contains(t, listener.KeyspaceUpdatedEvents[0].New.StrategyClass, "NetworkTopologyStrategy", "Expected keyspace updated event to have correct replication class")
++	require.Equal(t, "2", listener.KeyspaceUpdatedEvents[0].New.StrategyOptions["datacenter1"], "Expected keyspace updated event to have correct new replication factor")
+ 
+ 	time.Sleep(2 * time.Second)
+ 

--- a/versions/upstream/2.1.0/patch
+++ b/versions/upstream/2.1.0/patch
@@ -1,0 +1,397 @@
+diff --git a/batch_test.go b/batch_test.go
+index 57eafd6..a78ad42 100644
+--- a/batch_test.go
++++ b/batch_test.go
+@@ -122,9 +122,9 @@ func TestBatch_SetKeyspace(t *testing.T) {
+ 	const keyspaceStmt = `
+ 		CREATE KEYSPACE IF NOT EXISTS gocql_keyspace_override_test 
+ 		WITH replication = {
+-			'class': 'SimpleStrategy', 
+-			'replication_factor': '1'
+-		};
++			'class': 'NetworkTopologyStrategy', 
++			'datacenter1': '1'
++		} AND tablets = {'enabled': false};
+ `
+ 
+ 	err := session.Query(keyspaceStmt).Exec()
+diff --git a/cassandra_test.go b/cassandra_test.go
+index 2f386c8..060230a 100644
+--- a/cassandra_test.go
++++ b/cassandra_test.go
+@@ -2254,8 +2254,8 @@ func assertGetKeyspaceMetadata(t *testing.T, keyspaceMetadata *KeyspaceMetadata,
+ 	if keyspaceMetadata.Name != "gocql_test" {
+ 		t.Errorf("Expected keyspace name to be 'gocql' but was '%s'", keyspaceMetadata.Name)
+ 	}
+-	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.SimpleStrategy" {
+-		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.SimpleStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
++	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.NetworkTopologyStrategy" {
++		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.NetworkTopologyStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
+ 	}
+ 	if keyspaceMetadata.StrategyOptions == nil {
+ 		t.Error("Expected replication strategy options map but was nil")
+@@ -3912,8 +3912,8 @@ func TestQuery_SetKeyspace(t *testing.T) {
+ 	const keyspaceStmt = `
+ 		CREATE KEYSPACE IF NOT EXISTS gocql_query_keyspace_override_test
+ 		WITH replication = {
+-			'class': 'SimpleStrategy',
+-			'replication_factor': '1'
++			'class': 'NetworkTopologyStrategy',
++			'datacenter1': '1'
+ 		};
+ `
+ 
+@@ -4205,9 +4205,9 @@ func TestStmtCacheUsesOverriddenKeyspace(t *testing.T) {
+ 
+ 	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-			'replication_factor' : 1
+-	}`
++		'class' : 'NetworkTopologyStrategy',
++			'datacenter1' : 1
++	} AND tablets = {'enabled': false}`
+ 
+ 	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_stmt_cache"))
+ 	if err != nil {
+@@ -4266,9 +4266,9 @@ func TestRoutingKeyCacheUsesOverriddenKeyspace(t *testing.T) {
+ 
+ 	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-			'replication_factor' : 1
+-	}`
++		'class' : 'NetworkTopologyStrategy',
++			'datacenter1' : 1
++	} AND tablets = {'enabled': false}`
+ 
+ 	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_routing_key_cache"))
+ 	if err != nil {
+diff --git a/common_test.go b/common_test.go
+index 0ae7501..15beff3 100644
+--- a/common_test.go
++++ b/common_test.go
+@@ -161,9 +161,9 @@ func createKeyspaceWithRF(tb testing.TB, cluster *ClusterConfig, keyspace string
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : %d
+-	}`, keyspace, rf))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : %d
++	} AND tablets = {'enabled': false}`, keyspace, rf))
+ 
+ 	if err != nil {
+ 		panic(fmt.Sprintf("unable to create keyspace: %v", err))
+diff --git a/example_batch_test.go b/example_batch_test.go
+index 2322a3b..36c80b5 100644
+--- a/example_batch_test.go
++++ b/example_batch_test.go
+@@ -35,7 +35,7 @@ import (
+ // Example_batch demonstrates how to execute a batch of statements.
+ func Example_batch() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.batches(pk int, ck int, description text, PRIMARY KEY(pk, ck));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_dynamic_columns_test.go b/example_dynamic_columns_test.go
+index 38f4c66..f4816aa 100644
+--- a/example_dynamic_columns_test.go
++++ b/example_dynamic_columns_test.go
+@@ -38,7 +38,7 @@ import (
+ // Example_dynamicColumns demonstrates how to handle dynamic column list.
+ func Example_dynamicColumns() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.table1(pk text, ck int, value1 text, value2 int, PRIMARY KEY(pk, ck));
+ 	insert into example.table1 (pk, ck, value1, value2) values ('a', 1, 'b', 2);
+ 	insert into example.table1 (pk, ck, value1, value2) values ('c', 3, 'd', 4);
+diff --git a/example_event_listeners_test.go b/example_event_listeners_test.go
+index 942b2d5..f94b37f 100644
+--- a/example_event_listeners_test.go
++++ b/example_event_listeners_test.go
+@@ -201,7 +201,7 @@ func (l *HostStateListener) OnHostDown(event gocql.HostDownEvent) {
+ // (SchemaListenersMux, HostListenersMux, SessionReadyListenersMux).
+ func Example_eventListeners() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.events_demo(id int PRIMARY KEY, value text);
+ 	*/
+ 
+@@ -245,7 +245,7 @@ func Example_eventListeners() {
+ 	// Host Listener: Session ready, loading initial host state
+ 	//   Initial host: 127.0.0.1 (id: a1b2c3d4-e5f6-7890-abcd-ef1234567890, datacenter: datacenter1, rack: rack1, state: UP)
+ 	// Schema Listener: Session ready, loading initial schema state
+-	//   Initial keyspace: example (replication: org.apache.cassandra.locator.SimpleStrategy)
++	//   Initial keyspace: example (replication: org.apache.cassandra.locator.NetworkTopologyStrategy)
+ 	//     Initial table: example.events_demo
+ 	//   Initial keyspace: system (replication: org.apache.cassandra.locator.LocalStrategy)
+ 	//     Initial table: system.local
+diff --git a/example_lwt_batch_test.go b/example_lwt_batch_test.go
+index 1d0acad..ec5e09f 100644
+--- a/example_lwt_batch_test.go
++++ b/example_lwt_batch_test.go
+@@ -35,7 +35,7 @@ import (
+ // ExampleBatch_MapExecCAS demonstrates how to execute a batch lightweight transaction.
+ func ExampleBatch_MapExecCAS() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.my_lwt_batch_table(pk text, ck text, version int, value text, PRIMARY KEY(pk, ck));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_lwt_test.go b/example_lwt_test.go
+index a7aa0a8..0ac1e9a 100644
+--- a/example_lwt_test.go
++++ b/example_lwt_test.go
+@@ -35,7 +35,7 @@ import (
+ // ExampleQuery_MapScanCAS demonstrates how to execute a single-statement lightweight transaction.
+ func ExampleQuery_MapScanCAS() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.my_lwt_table(pk int, version int, value text, PRIMARY KEY(pk));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_marshaler_test.go b/example_marshaler_test.go
+index 3b6c819..6a6021e 100644
+--- a/example_marshaler_test.go
++++ b/example_marshaler_test.go
+@@ -75,7 +75,7 @@ func (m *MyMarshaler) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
+ // Example_marshalerUnmarshaler demonstrates how to implement a Marshaler and Unmarshaler.
+ func Example_marshalerUnmarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.my_marshaler_table(pk int, value text, PRIMARY KEY(pk));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_nulls_test.go b/example_nulls_test.go
+index 4d0ab16..20b4cf2 100644
+--- a/example_nulls_test.go
++++ b/example_nulls_test.go
+@@ -37,7 +37,7 @@ import (
+ // column being null and empty string, you can unmarshal into *string field.
+ func Example_nulls() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.stringvals(id int, value text, PRIMARY KEY(id));
+ 	insert into example.stringvals (id, value) values (1, null);
+ 	insert into example.stringvals (id, value) values (2, '');
+diff --git a/example_paging_test.go b/example_paging_test.go
+index 8e2a123..76bb2a5 100644
+--- a/example_paging_test.go
++++ b/example_paging_test.go
+@@ -36,7 +36,7 @@ import (
+ // See also package documentation about paging.
+ func Example_paging() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.itoa(id int, description text, PRIMARY KEY(id));
+ 	insert into example.itoa (id, description) values (1, 'one');
+ 	insert into example.itoa (id, description) values (2, 'two');
+diff --git a/example_set_test.go b/example_set_test.go
+index faf73ea..aa6f4a8 100644
+--- a/example_set_test.go
++++ b/example_set_test.go
+@@ -35,7 +35,7 @@ import (
+ // Example_set demonstrates how to use sets.
+ func Example_set() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.sets(id int, value set<text>, PRIMARY KEY(id));
+ 	*/
+ 	cluster := gocql.NewCluster("localhost:9042")
+diff --git a/example_setkeyspace_test.go b/example_setkeyspace_test.go
+index 93b9c1c..946d9e0 100644
+--- a/example_setkeyspace_test.go
++++ b/example_setkeyspace_test.go
+@@ -35,9 +35,9 @@ import (
+ // 3. Default session keyspace - LOWEST precedence
+ func Example_setKeyspace() {
+ 	/* The example assumes the following CQL was used to setup the keyspaces:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+-	create keyspace example2 with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+-	create keyspace example3 with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
++	create keyspace example2 with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
++	create keyspace example3 with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.users(id int, name text, PRIMARY KEY(id));
+ 	create table example2.users(id int, name text, PRIMARY KEY(id));
+ 	create table example3.users(id int, name text, PRIMARY KEY(id));
+diff --git a/example_structured_logging_test.go b/example_structured_logging_test.go
+index c5bd366..dcbb227 100644
+--- a/example_structured_logging_test.go
++++ b/example_structured_logging_test.go
+@@ -39,7 +39,7 @@ import (
+ // proper component separation to distinguish between application and driver logs.
+ func Example_structuredLogging() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.log_demo(id int, value text, PRIMARY KEY(id));
+ 	*/
+ 
+diff --git a/example_test.go b/example_test.go
+index 9172519..46215a4 100644
+--- a/example_test.go
++++ b/example_test.go
+@@ -34,7 +34,7 @@ import (
+ 
+ func Example() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.tweet(timeline text, id UUID, text text, PRIMARY KEY(id));
+ 	create index on example.tweet(timeline);
+ 	*/
+diff --git a/example_udt_map_test.go b/example_udt_map_test.go
+index 03018c3..52a99cf 100644
+--- a/example_udt_map_test.go
++++ b/example_udt_map_test.go
+@@ -36,7 +36,7 @@ import (
+ // See also Example_userDefinedTypesStruct and examples for UDTMarshaler and UDTUnmarshaler if you want to map to structs.
+ func Example_userDefinedTypesMap() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_marshaler_test.go b/example_udt_marshaler_test.go
+index b2dc6ac..b385d8e 100644
+--- a/example_udt_marshaler_test.go
++++ b/example_udt_marshaler_test.go
+@@ -55,7 +55,7 @@ func (m MyUDTMarshaler) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, er
+ // ExampleUDTMarshaler demonstrates how to implement a UDTMarshaler.
+ func ExampleUDTMarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_struct_test.go b/example_udt_struct_test.go
+index 1bfdc7b..fb23bb2 100644
+--- a/example_udt_struct_test.go
++++ b/example_udt_struct_test.go
+@@ -41,7 +41,7 @@ type MyUDT struct {
+ // See also examples for UDTMarshaler and UDTUnmarshaler if you need more control/better performance.
+ func Example_userDefinedTypesStruct() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	*/
+diff --git a/example_udt_unmarshaler_test.go b/example_udt_unmarshaler_test.go
+index 2db6c61..d0c331f 100644
+--- a/example_udt_unmarshaler_test.go
++++ b/example_udt_unmarshaler_test.go
+@@ -56,7 +56,7 @@ func (m *MyUDTUnmarshaler) UnmarshalUDT(name string, info gocql.TypeInfo, data [
+ // ExampleUDTUnmarshaler demonstrates how to implement a UDTUnmarshaler.
+ func ExampleUDTUnmarshaler() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create type example.my_udt (field_a text, field_b int);
+ 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
+ 	insert into example.my_udt_table (pk, value) values (1, {field_a: 'a value', field_b: 42});
+diff --git a/example_vector_test.go b/example_vector_test.go
+index 8e88c32..b7bb6c1 100644
+--- a/example_vector_test.go
++++ b/example_vector_test.go
+@@ -32,7 +32,7 @@ import (
+ // Note: Requires Cassandra 5.0+ and a SAI index on the vector column for ANN search.
+ func Example_vector() {
+ 	/* The example assumes the following CQL was used to setup the keyspace:
+-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
++	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
+ 	create table example.vectors(
+ 		id int,
+ 		item_name text,
+diff --git a/keyspace_table_test.go b/keyspace_table_test.go
+index 7862b48..d3d7a88 100644
+--- a/keyspace_table_test.go
++++ b/keyspace_table_test.go
+@@ -61,9 +61,9 @@ func TestKeyspaceTable(t *testing.T) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : 1
+-	}`, keyspace))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : 1
++	} AND tablets = {'enabled': false}`, keyspace))
+ 
+ 	if err != nil {
+ 		t.Fatal("unable to create keyspace:", err)
+@@ -71,9 +71,9 @@ func TestKeyspaceTable(t *testing.T) {
+ 
+ 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+ 	WITH replication = {
+-		'class' : 'SimpleStrategy',
+-		'replication_factor' : 1
+-	}`, wrongKeyspace))
++		'class' : 'NetworkTopologyStrategy',
++		'datacenter1' : 1
++	} AND tablets = {'enabled': false}`, wrongKeyspace))
+ 
+ 	if err != nil {
+ 		t.Fatal("unable to create keyspace:", err)
+diff --git a/schema_events_test.go b/schema_events_test.go
+index ae9e245..3301f91 100644
+--- a/schema_events_test.go
++++ b/schema_events_test.go
+@@ -211,7 +211,7 @@ func testSchemaEventsKeyspace(t *testing.T, session *Session, listener *schemaCh
+ 
+ 	listener.clear()
+ 
+-	err := session.Query(fmt.Sprintf(`CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}`, ks)).Exec()
++	err := session.Query(fmt.Sprintf(`CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '1'} AND tablets = {'enabled': false}`, ks)).Exec()
+ 	require.NoError(t, err, "Expected no error creating keyspace")
+ 
+ 	require.Eventually(t, func() bool {
+@@ -220,12 +220,12 @@ func testSchemaEventsKeyspace(t *testing.T, session *Session, listener *schemaCh
+ 
+ 	// Verify that the listener received the keyspace created event
+ 	require.Equal(t, ks, listener.KeyspaceCreatedEvents[0].Keyspace.Name, "Expected keyspace created event to have correct keyspace name")
+-	require.Contains(t, listener.KeyspaceCreatedEvents[0].Keyspace.StrategyClass, "SimpleStrategy", "Expected keyspace created event to have correct replication class")
+-	require.Equal(t, "1", listener.KeyspaceCreatedEvents[0].Keyspace.StrategyOptions["replication_factor"], "Expected keyspace created event to have correct replication factor")
++	require.Contains(t, listener.KeyspaceCreatedEvents[0].Keyspace.StrategyClass, "NetworkTopologyStrategy", "Expected keyspace created event to have correct replication class")
++	require.Equal(t, "1", listener.KeyspaceCreatedEvents[0].Keyspace.StrategyOptions["datacenter1"], "Expected keyspace created event to have correct replication factor")
+ 
+ 	listener.clear()
+ 
+-	err = session.Query(fmt.Sprintf(`ALTER KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '2'}`, ks)).Exec()
++	err = session.Query(fmt.Sprintf(`ALTER KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '2'}`, ks)).Exec()
+ 	require.NoError(t, err, "Expected no error updating keyspace")
+ 
+ 	// Verify that the listener received the keyspace updated event
+@@ -237,13 +237,13 @@ func testSchemaEventsKeyspace(t *testing.T, session *Session, listener *schemaCh
+ 
+ 	// Old metadata
+ 	require.Equal(t, ks, listener.KeyspaceUpdatedEvents[0].Old.Name, "Expected keyspace updated event to have correct keyspace name")
+-	require.Contains(t, listener.KeyspaceUpdatedEvents[0].Old.StrategyClass, "SimpleStrategy", "Expected keyspace created event to have correct replication class")
+-	require.Equal(t, "1", listener.KeyspaceUpdatedEvents[0].Old.StrategyOptions["replication_factor"], "Expected keyspace updated event to have correct old replication factor")
++	require.Contains(t, listener.KeyspaceUpdatedEvents[0].Old.StrategyClass, "NetworkTopologyStrategy", "Expected keyspace created event to have correct replication class")
++	require.Equal(t, "1", listener.KeyspaceUpdatedEvents[0].Old.StrategyOptions["datacenter1"], "Expected keyspace updated event to have correct old replication factor")
+ 
+ 	// New metadata
+ 	require.Equal(t, ks, listener.KeyspaceUpdatedEvents[0].New.Name, "Expected keyspace updated event to have correct keyspace name")
+-	require.Contains(t, listener.KeyspaceUpdatedEvents[0].New.StrategyClass, "SimpleStrategy", "Expected keyspace updated event to have correct replication class")
+-	require.Equal(t, "2", listener.KeyspaceUpdatedEvents[0].New.StrategyOptions["replication_factor"], "Expected keyspace updated event to have correct new replication factor")
++	require.Contains(t, listener.KeyspaceUpdatedEvents[0].New.StrategyClass, "NetworkTopologyStrategy", "Expected keyspace updated event to have correct replication class")
++	require.Equal(t, "2", listener.KeyspaceUpdatedEvents[0].New.StrategyOptions["datacenter1"], "Expected keyspace updated event to have correct new replication factor")
+ 
+ 	time.Sleep(2 * time.Second)
+ 


### PR DESCRIPTION
## 🐛 Problems

Two independent issues causing test failures against Scylla 2026.2+:

1. **Upstream driver tests fail with `SimpleStrategy doesn't support tablet replication`** — Scylla 2026.2 enables tablets by default, and `SimpleStrategy` is incompatible. Visible in Jenkins build #852 where `apache/cassandra-gocql-driver` v2.1.1 and v2.0.0 failed while `scylladb/gocql` versions passed (they already use NTS in their test helpers).

2. **`scylladb/gocql` v1.18.0 had 79 `DATA RACE` failures** — v1.18.0 added `t.Parallel()` to integration tests, exposing a pre-existing data race in `scyllaConnPicker` (no internal `sync.RWMutex`). The `1.17.3` patch could no longer be applied to v1.18.0 either, since all 5 patched files were incorporated natively.

## ✅ Solution

### 📦 Commit 1: Upstream SimpleStrategy → NTS + scylla v1.18.0 version dir

#### `versions/upstream/2.1.0/patch` (applies to v2.1.1)
Patches 22 files:
- `common_test.go` — `createKeyspaceWithRF` helper (critical fix)
- `keyspace_table_test.go`, `batch_test.go`, `cassandra_test.go` — keyspace creation in tests
- 17 `example_*_test.go` files — documentation comments

Functional test keyspaces also get `AND tablets = {'enabled': false}` where tablet-sensitive operations (token-aware routing, LWT, schema events) are performed. Example documentation comments use NTS alone — `AND tablets` is a ScyllaDB-specific extension that would fail against Apache Cassandra.

#### `versions/upstream/2.0.0/patch` (applies to v2.0.0)
Same as above minus `example_event_listeners_test.go` and `schema_events_test.go` which don't exist in v2.0.0 (20 files total).

Both patches verified with `patch --dry-run` on fresh checkouts of the respective tags.

#### `versions/scylla/1.18.0/ignore.yaml`
Empty skip lists — ensures v1.18.0 is recognized by the matrix runner and the `1.17.3` patch is not incorrectly applied to it.

### 🔧 Commit 2: scylla v1.18.0 data race fix

`scyllaConnPicker` had no internal synchronization. The race: `hostConnPool.Close()` releases `pool.mu` then calls `connPicker.Close()` which writes `p.conns = nil` / `p.nrConns = 0` — while concurrent `fill()` goroutines still hold `pool.mu` and call `connPicker.Size()` / `connPicker.NextShard()` reading the same fields.

`versions/scylla/1.18.0/patch` adds `sync.RWMutex` to `scyllaConnPicker`, mirroring `defaultConnPicker`'s existing pattern. See scylladb/gocql#872 for full analysis and the upstream fix.

## 🧪 Testing

- ✅ [Staging build #3](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/gocql-driver-matrix-master/3/) — **all 6 runs pass, 0 failures** against Scylla 2026.3.0~dev:

| Driver | Protocol | Tests | Passed | Failed | Skipped |
|---|---|---|---|---|---|
| 🦎 scylla v1.18.0 | v3 | 458 | 442 | **0** | 16 |
| 🦎 scylla v1.18.0 | v4 | 454 | 441 | **0** | 13 |
| 🐿️ upstream v2.1.1 | v3 | 211 | 208 | **0** | 3 |
| 🐿️ upstream v2.1.1 | v4 | 210 | 208 | **0** | 2 |
| 🐿️ upstream v2.0.0 | v3 | 210 | 207 | **0** | 3 |
| 🐿️ upstream v2.0.0 | v4 | 209 | 207 | **0** | 2 |

> 📈 **Before these fixes:** scylla v1.18.0 had **79 DATA RACE failures**; upstream v2.1.1/v2.0.0 had **SimpleStrategy failures**. After: **0 failures across all 6 runs**.

## 🔗 Related

- scylladb/gocql#854 — companion SimpleStrategy → NTS fix in `scylladb/gocql` example files
- scylladb/gocql#872 — upstream data race fix (source of the `versions/scylla/1.18.0/patch`)