### PR TITLE
Add auth integration tests to matrix

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,7 +25,7 @@ on:
         description: Optional test selector passed through to the runner.
         required: false
         type: string
-        default: "integration"
+        default: "integration auth"
       protocols:
         description: Optional protocol list passed through to the runner.
         required: false
@@ -209,7 +209,8 @@ jobs:
           versions="${DRIVER_REF:-1}"
           args=(./scripts/run_test.sh --versions "$versions" --protocols "$PROTOCOLS" --scylla-version "$SCYLLA_VERSION")
           if [ -n "$TESTS" ]; then
-            args+=(--tests "$TESTS")
+            read -r -a test_args <<< "$TESTS"
+            args+=(--tests "${test_args[@]}")
           fi
           "${args[@]}"
 

--- a/README.md
+++ b/README.md
@@ -33,19 +33,20 @@ All repositories should be under the **same base folder**
     * Regardless if this is Scylla or Upstream driver (script automatically discovers based on git origin source):
       ```bash
       # Run all standard tests on latest gocql tag (--versions 1)
-      python3 main.py ../gocql-upstream --tests integration --versions 1 --protocols 3,4 --scylla-version release:5.2.4
+      python3 main.py ../gocql-upstream --tests integration auth --versions 1 --protocols 3,4 --scylla-version release:5.2.4
 
       # Run all standard tests with specific gocql tag (--versions 1.8.0)
-      python3 main.py ../gocql-scylla --tests integration --versions v1.8.0 --protocols 3,4 --scylla-version release:5.2.4
+      python3 main.py ../gocql-scylla --tests integration auth --versions v1.8.0 --protocols 3,4 --scylla-version release:5.2.4
       ```
 
 ## Running locally with docker
 ```bash
 export GOCQL_DRIVER_DIR=`pwd`/../gocql-scylla
-scripts/run_test.sh --tests integration --versions 1 --protocols 3 --scylla-version release:5.2.4
+scripts/run_test.sh --tests integration auth --versions 1 --protocols 3 --scylla-version release:5.2.4
 
 ```
 
 ## Available tests:
 * integration
+* auth
 * ccm

--- a/configurations.py
+++ b/configurations.py
@@ -1,18 +1,31 @@
 from dataclasses import dataclass
-from typing import Literal, List, Dict
+from typing import Any, List, Dict
 
 
 @dataclass
 class TestConfiguration:
     tags: List[str]
     test_command_args: str
-    cluster_configuration: Dict[str, str]
+    cluster_configuration: Dict[str, Any]
+    startup_delay_seconds: int = 0
 
 
 integration_tests = TestConfiguration(tags=["integration"], test_command_args='-timeout=10m -race -tags="integration"', cluster_configuration={})
+auth_tests = TestConfiguration(
+    tags=["integration"],
+    test_command_args='-timeout=5m -tags="integration" -run=TestAuthentication -runauth',
+    cluster_configuration={
+        "authenticator": "PasswordAuthenticator",
+        "authorizer": "CassandraAuthorizer",
+        "auth_superuser_name": "cassandra",
+        "auth_superuser_salted_password": "$6$x7IFjiX5VCpvNiFk$2IfjTvSyGL7zerpV.wbY7mJjaRCrJ/68dtT3UpT.sSmNYz1bPjtn3mH.kJKFvaZ2T4SbVeBijjmwGjcb83LlV/",
+    },
+    startup_delay_seconds=30,
+)
 ccm_tests = TestConfiguration(tags=["ccm"], test_command_args='-timeout=10m -race -tags="ccm"', cluster_configuration={})
 
 test_config_map = {
     "integration": integration_tests,
+    "auth": auth_tests,
     "ccm": ccm_tests,
 }

--- a/main.py
+++ b/main.py
@@ -89,8 +89,8 @@ def get_arguments() -> argparse.Namespace:
                         help="gocql-driver versions to test\n"
                              "The value can be number or str with comma (example: 'v1.8.0,v1.7.3').\n"
                              "default=2 - take the two latest driver's tags.")
-    parser.add_argument('--tests', default='integration',
-                        help='"tags" to pass to go test command, default=integration', nargs='+', choices=['integration', 'ccm'])
+    parser.add_argument('--tests', default=['integration', 'auth'],
+                        help='"tags" to pass to go test command, default=integration auth', nargs='+', choices=['integration', 'auth', 'ccm'])
     parser.add_argument('--protocols', default=default_protocols,
                         help='cqlsh native protocol, default={}'.format(','.join(default_protocols)))
     parser.add_argument('--scylla-version', help="relocatable scylla version to use",

--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import json
+import time
 from functools import cached_property
 from pathlib import Path
 from typing import Dict, List
@@ -167,6 +168,13 @@ class Run:
                 skip_tests = f'-skip "{"|".join(self.ignore_tests["skip"]) if self.ignore_tests.get("skip") else ""}"'
                 with TestCluster(self._gocql_driver_git, self._scylla_version, configuration=test_config.cluster_configuration) as cluster:
                     cluster_params = cluster.start()
+                    if test_config.startup_delay_seconds:
+                        logging.info(
+                            "Waiting %d seconds before running tests for tag '%s'",
+                            test_config.startup_delay_seconds,
+                            test,
+                        )
+                        time.sleep(test_config.startup_delay_seconds)
                     if test == 'ccm':
                         # CCM-tagged Go tests manage the cluster lifecycle themselves via ccm start/stop.
                         # Stop the cluster so the Go test's ccm.StartAll() can start it successfully.

--- a/tests/test_pr_integration_changes.py
+++ b/tests/test_pr_integration_changes.py
@@ -18,11 +18,20 @@ def test_runner_changes_include_shell_wrapper_entrypoint_and_workflows():
         "scripts/image",
         ".github/workflows/integration-tests.yml",
         ".github/workflows/pr-integration-tests.yml",
+        "configurations.py",
         "main.py",
     ]:
         outputs = detect_changes([changed_file], repo_root=REPO_ROOT)
 
         assert outputs["runner_changed"] == "true", changed_file
+
+
+def test_integration_workflow_runs_auth_by_default_and_splits_test_args():
+    workflow = (REPO_ROOT / ".github/workflows/integration-tests.yml").read_text(encoding="utf-8")
+
+    assert 'default: "integration auth"' in workflow
+    assert 'read -r -a test_args <<< "$TESTS"' in workflow
+    assert 'args+=(--tests "${test_args[@]}")' in workflow
 
 
 def test_changed_scylla_version_expands_to_driver_matrix_entry():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,4 +1,43 @@
+import sys
+
+from configurations import test_config_map
+from main import get_arguments
 from run import Run
+
+
+def test_default_tests_include_auth(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "main.py",
+            ".",
+            "--versions",
+            "v1.18.3",
+            "--protocols",
+            "4",
+            "--scylla-version",
+            "release:2026.2.0",
+        ],
+    )
+
+    arguments = get_arguments()
+
+    assert arguments.tests == ["integration", "auth"]
+
+
+def test_auth_configuration_enables_cluster_auth_and_selects_auth_test():
+    auth_config = test_config_map["auth"]
+
+    assert auth_config.cluster_configuration == {
+        "authenticator": "PasswordAuthenticator",
+        "authorizer": "CassandraAuthorizer",
+        "auth_superuser_name": "cassandra",
+        "auth_superuser_salted_password": "$6$x7IFjiX5VCpvNiFk$2IfjTvSyGL7zerpV.wbY7mJjaRCrJ/68dtT3UpT.sSmNYz1bPjtn3mH.kJKFvaZ2T4SbVeBijjmwGjcb83LlV/",
+    }
+    assert "-run=TestAuthentication" in auth_config.test_command_args
+    assert "-runauth" in auth_config.test_command_args
+    assert auth_config.startup_delay_seconds == 30
 
 
 def test_gocql_cversion_defaults_to_cassandra_version():

--- a/versions/scylla/1.18.0/patch
+++ b/versions/scylla/1.18.0/patch
@@ -168,3 +168,17 @@ index af15d50..cec703b 100644
  	// Find the shard without a connection
  	// It's important to start counting from 1 here because we want
  	// to consider the next shard after the previously attempted one
+
+diff --git a/common_test.go b/common_test.go
+index e32244d..30c5b21 100644
+--- a/common_test.go
++++ b/common_test.go
+@@ -66,7 +66,7 @@ func init() {
+ 
+ func TestMain(m *testing.M) {
+ 	flag.Parse()
+-	if integrationTestSetup != nil {
++	if integrationTestSetup != nil && !*flagRunAuthTest {
+ 		integrationTestSetup()
+ 	}
+ 	os.Exit(m.Run())

--- a/versions/scylla/1.18.1/patch
+++ b/versions/scylla/1.18.1/patch
@@ -1,0 +1,13 @@
+diff --git a/common_test.go b/common_test.go
+index e32244d..30c5b21 100644
+--- a/common_test.go
++++ b/common_test.go
+@@ -66,7 +66,7 @@ func init() {
+ 
+ func TestMain(m *testing.M) {
+ 	flag.Parse()
+-	if integrationTestSetup != nil {
++	if integrationTestSetup != nil && !*flagRunAuthTest {
+ 		integrationTestSetup()
+ 	}
+ 	os.Exit(m.Run())


### PR DESCRIPTION
## Summary
- add an `auth` test selector that enables Scylla auth and runs `TestAuthentication` with `-runauth`
- include `integration auth` in the default matrix workflow and split multi-test workflow inputs into separate CLI args
- document the auth selector and add regression tests

Closes #8

## Testing
- `python3 -m pytest -q`
- `python3 -m py_compile configurations.py run.py main.py scripts/pr_integration_changes.py`